### PR TITLE
Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - test(E2E): Add more start/stop cli plugin E2E tests
+- test(E2E): Add alerts E2E tests
 
 ### Changed
 - Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update dependencies
 - Update core version to [1.6.0](https://github.com/mocks-server/core/releases/tag/v1.6.0)
-- Update plugin-inquirer-cli version to [1.4.0](https://github.com/mocks-server/plugin-inquirer-cli/releases/tag/v1.4.0)
+- Update plugin-inquirer-cli version to [1.4.1](https://github.com/mocks-server/plugin-inquirer-cli/releases/tag/v1.4.1)
 - Update plugin-admin-api version to [1.5.0](https://github.com/mocks-server/plugin-admin-api/releases/tag/v1.5.0)
 - test(E2E): Move support files to support folder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.9.0] - 2020-12-25
+### Changed
+- Update dependencies
+- Update core version to [1.6.0](https://github.com/mocks-server/core/releases/tag/v1.6.0)
+- Update plugin-inquirer-cli version to [1.4.0](https://github.com/mocks-server/plugin-inquirer-cli/releases/tag/v1.4.0)
+- Update plugin-admin-api version to [1.5.0](https://github.com/mocks-server/plugin-admin-api/releases/tag/v1.5.0)
+- test(E2E): Move support files to support folder
+
 ## [1.8.8] - 2020-12-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ## [1.9.0] - 2020-12-25
+
+### Added
+- test(E2E): Add more start/stop cli plugin E2E tests
+
 ### Changed
 - Update dependencies
 - Update core version to [1.6.0](https://github.com/mocks-server/core/releases/tag/v1.6.0)

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -5,8 +5,8 @@ module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
-  testMatch: ["**/test/e2e/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["**/test/acceptance/config-file.spec.js"],
+  testMatch: ["<rootDir>/test/e2e/*.spec.js"],
+  // testMatch: ["**/test/e2e/cli-disabled-runtime.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["<rootDir>/test/e2e/*.spec.js"],
-  // testMatch: ["**/test/e2e/cli-disabled-runtime.spec.js"],
+  // testMatch: ["<rootDir>/test/e2e/cli-disabled-runtime.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/main",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -704,14 +704,14 @@
       }
     },
     "@mocks-server/admin-api-paths": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@mocks-server/admin-api-paths/-/admin-api-paths-1.0.8.tgz",
-      "integrity": "sha512-UH7PqoUWhUjUexP5IeS08frHKsKa5mzLi/HosbWLxo0rkk6SqzOmxg+2mtBPPx+y/Pw8RygfiwvRdUJGvK1byA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mocks-server/admin-api-paths/-/admin-api-paths-1.1.0.tgz",
+      "integrity": "sha512-qFcIsRtfD9uXj3Js0qKyKZKUeoCgzcjxZWPw3Xe64bPByE5lrPYlMzVMbmENVLIkQS5aOlVttxOzpG8jHO/DxA=="
     },
     "@mocks-server/core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@mocks-server/core/-/core-1.5.1.tgz",
-      "integrity": "sha512-RIJlVpzi0MIDt163B0Bi6gA5DbrJwm1IZgwJhHCprPXoD24x7KbA3q5b12LdJdayRx/BXvtmn1zX+piZqCRhmQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@mocks-server/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-Gh2C7RGXvs09x7qDArby2XN1G11iOyLY5AcZzSaJXHM59F59NV9E17rNKf5i8S2XJVv1aNA4WO/AqsIfMFDcXQ==",
       "requires": {
         "@hapi/boom": "9.1.0",
         "body-parser": "1.19.0",
@@ -730,24 +730,25 @@
       }
     },
     "@mocks-server/plugin-admin-api": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-admin-api/-/plugin-admin-api-1.4.7.tgz",
-      "integrity": "sha512-sk3g5dhC3X74g4D53ZuZdVHjlkVqRwF20mhtyv7YoRuiW836rO6ZlpLvX2fRdR11M7uia9e36xaXihTob5P5jg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-admin-api/-/plugin-admin-api-1.5.0.tgz",
+      "integrity": "sha512-yR5RQ4zgNxO4iR206tV5tWOpqKaGw5CHvXY1qUkGK3h6Kj8M+qNu/I8JWihx/mAvoW/LgUvzFylNAFQEY9MewQ==",
       "requires": {
         "@hapi/boom": "9.1.0",
-        "@mocks-server/admin-api-paths": "1.0.8",
+        "@mocks-server/admin-api-paths": "1.1.0",
         "express": "4.17.1"
       }
     },
     "@mocks-server/plugin-inquirer-cli": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-inquirer-cli/-/plugin-inquirer-cli-1.3.7.tgz",
-      "integrity": "sha512-Huch+szM2+D0oGgGFWCr1S5iUaG8PuQsAxEZzLqvs1BJUcbTQi/DVGnd3KIZcr+7FCdQbpktdwE0ZRgskBHF9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-inquirer-cli/-/plugin-inquirer-cli-1.4.0.tgz",
+      "integrity": "sha512-ywl0pUg9G7jqyzB9sZ+OQHz/VbvOhmzlNNMlSYC+G1px8oxfFqWVFnaJFd0na7XRBMK7Z4mFeuP6ww/qdDbYeQ==",
       "requires": {
         "chalk": "4.1.0",
         "inquirer": "7.3.3",
         "inquirer-autocomplete-prompt": "1.3.0",
-        "lodash": "4.17.20"
+        "lodash": "4.17.20",
+        "node-emoji": "1.10.0"
       },
       "dependencies": {
         "chalk": {
@@ -4170,6 +4171,11 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -4223,9 +4229,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -4427,6 +4433,14 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "requires": {
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,9 +740,9 @@
       }
     },
     "@mocks-server/plugin-inquirer-cli": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-inquirer-cli/-/plugin-inquirer-cli-1.4.0.tgz",
-      "integrity": "sha512-ywl0pUg9G7jqyzB9sZ+OQHz/VbvOhmzlNNMlSYC+G1px8oxfFqWVFnaJFd0na7XRBMK7Z4mFeuP6ww/qdDbYeQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-inquirer-cli/-/plugin-inquirer-cli-1.4.1.tgz",
+      "integrity": "sha512-njA1fxorXaueoH4VU2j4YMLbvxpm058s2Xav2OOovUXY5lU1EWpBJ0zBEDolsjnkQNsx0MnfRPopsCwxjfcORw==",
       "requires": {
         "chalk": "4.1.0",
         "inquirer": "7.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/main",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "description": "Mocks server supporting multiple api behaviors",
   "keywords": [
     "mocks",
@@ -39,9 +39,9 @@
     "test:unit": "npm run test"
   },
   "dependencies": {
-    "@mocks-server/core": "1.5.1",
-    "@mocks-server/plugin-admin-api": "1.4.7",
-    "@mocks-server/plugin-inquirer-cli": "1.3.7"
+    "@mocks-server/core": "1.6.0",
+    "@mocks-server/plugin-admin-api": "1.5.0",
+    "@mocks-server/plugin-inquirer-cli": "1.4.0"
   },
   "devDependencies": {
     "eslint": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@mocks-server/core": "1.6.0",
     "@mocks-server/plugin-admin-api": "1.5.0",
-    "@mocks-server/plugin-inquirer-cli": "1.4.0"
+    "@mocks-server/plugin-inquirer-cli": "1.4.1"
   },
   "devDependencies": {
     "eslint": "7.16.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server-main
-sonar.projectVersion=1.8.8
+sonar.projectVersion=1.9.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/test/e2e/cli-arguments.spec.js
+++ b/test/e2e/cli-arguments.spec.js
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { CliRunner, request, wait, TimeCounter, BINARY_PATH } = require("./utils");
+const { CliRunner, request, wait, TimeCounter, BINARY_PATH } = require("./support/utils");
 
 describe("command line arguments", () => {
   const cwdPath = path.resolve(__dirname, "fixtures");

--- a/test/e2e/cli-disabled-arguments.spec.js
+++ b/test/e2e/cli-disabled-arguments.spec.js
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { CliRunner, request, wait, TimeCounter, BINARY_PATH } = require("./utils");
+const { CliRunner, request, wait, TimeCounter, BINARY_PATH } = require("./support/utils");
 
 describe("command line arguments with cli disabled", () => {
   const cwdPath = path.resolve(__dirname, "fixtures");

--- a/test/e2e/cli-disabled-runtime.spec.js
+++ b/test/e2e/cli-disabled-runtime.spec.js
@@ -167,5 +167,31 @@ describe("Cli stop method", () => {
       const newScreen = await cli.pressEnter();
       expect(newScreen).toEqual(expect.stringContaining("Log level: silly"));
     });
+
+    it("should display alerts when there is an error in files", async () => {
+      expect.assertions(2);
+      await request("/admin/settings", {
+        method: "PATCH",
+        body: {
+          path: "files-error",
+        },
+      });
+      await wait(2000);
+      expect(cli.currentScreen).toEqual(expect.stringContaining("ALERTS"));
+      expect(cli.currentScreen).toEqual(
+        expect.stringContaining("Error loading files from folder")
+      );
+    });
+
+    it("should not display alerts when error in files is fixed", async () => {
+      await request("/admin/settings", {
+        method: "PATCH",
+        body: {
+          path: "web-tutorial",
+        },
+      });
+      await wait(2000);
+      expect(cli.currentScreen).toEqual(expect.not.stringContaining("ALERTS"));
+    });
   });
 });

--- a/test/e2e/cli-disabled-runtime.spec.js
+++ b/test/e2e/cli-disabled-runtime.spec.js
@@ -60,7 +60,7 @@ describe("Cli stop method", () => {
           cli: false,
         },
       });
-      await wait();
+      await wait(3000);
     });
 
     it("should not display cli", async () => {
@@ -150,7 +150,7 @@ describe("Cli stop method", () => {
           cli: true,
         },
       });
-      await wait(2000);
+      await wait(3000);
     });
 
     it("should display cli", async () => {

--- a/test/e2e/cli-disabled-runtime.spec.js
+++ b/test/e2e/cli-disabled-runtime.spec.js
@@ -9,8 +9,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { request, wait, BINARY_PATH } = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+const { request, wait, BINARY_PATH } = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 describe("Cli stop method", () => {
   let cli;
@@ -65,7 +65,7 @@ describe("Cli stop method", () => {
 
     it("should not display cli", async () => {
       await request("/api/users");
-      expect(cli.logs).toEqual(expect.stringContaining("Request received | GET => /api/users"));
+      expect(cli.currentScreen).toEqual(expect.not.stringContaining("CURRENT SETTINGS"));
     });
 
     it("should not work to select log level using cli", async () => {
@@ -80,7 +80,7 @@ describe("Cli stop method", () => {
     });
   });
 
-  describe("when using api plugin to disable inquirer-cli", () => {
+  describe("when using api plugin to enable inquirer-cli", () => {
     beforeAll(async () => {
       cli.flush();
       await request("/admin/settings", {
@@ -89,14 +89,12 @@ describe("Cli stop method", () => {
           cli: true,
         },
       });
-      await wait();
+      await wait(2000);
     });
 
-    it("should not display cli", async () => {
+    it("should display cli", async () => {
       await request("/api/users");
-      expect(cli.logs).not.toEqual(
-        expect.stringContaining("Request received | GET => /api/users")
-      );
+      expect(cli.currentScreen).toEqual(expect.stringContaining("CURRENT SETTINGS"));
     });
 
     it("should display new selected log level", async () => {

--- a/test/e2e/cli-no-behaviors.spec.js
+++ b/test/e2e/cli-no-behaviors.spec.js
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { CliRunner, wait, BINARY_PATH } = require("./utils");
+const { CliRunner, wait, BINARY_PATH } = require("./support/utils");
 
 describe("with no behaviors", () => {
   const cwdPath = path.resolve(__dirname, "fixtures");

--- a/test/e2e/config-file.spec.js
+++ b/test/e2e/config-file.spec.js
@@ -9,8 +9,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { request, wait, BINARY_PATH } = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+const { request, wait, BINARY_PATH } = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 describe("web tutorial", () => {
   let cli;

--- a/test/e2e/delay-setting.spec.js
+++ b/test/e2e/delay-setting.spec.js
@@ -8,7 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-const { startServer, stopServer, request, changeDelay, TimeCounter } = require("./utils");
+const { startServer, stopServer, request, changeDelay, TimeCounter } = require("./support/utils");
 
 describe("delay setting", () => {
   let server;

--- a/test/e2e/deprecated-delay-setting.spec.js
+++ b/test/e2e/deprecated-delay-setting.spec.js
@@ -14,7 +14,7 @@ const {
   request,
   deprecatedChangeDelay,
   TimeCounter,
-} = require("./utils");
+} = require("./support/utils");
 
 describe("delay setting", () => {
   let server;

--- a/test/e2e/deprecated.cli-arguments.spec.js
+++ b/test/e2e/deprecated.cli-arguments.spec.js
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { CliRunner, request, wait, BINARY_PATH } = require("./utils");
+const { CliRunner, request, wait, BINARY_PATH } = require("./support/utils");
 
 describe("command line arguments", () => {
   const cwdPath = path.resolve(__dirname, "fixtures");

--- a/test/e2e/fixtures/files-error/standard.js
+++ b/test/e2e/fixtures/files-error/standard.js
@@ -1,0 +1,2 @@
+//eslint-disable-next-line
+module.exports = Foo

--- a/test/e2e/interactive-cli.spec.js
+++ b/test/e2e/interactive-cli.spec.js
@@ -9,8 +9,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { request, wait, TimeCounter, BINARY_PATH } = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+const { request, wait, TimeCounter, BINARY_PATH } = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 describe("interactive CLI", () => {
   let cli;

--- a/test/e2e/programmatic-cli.spec.js
+++ b/test/e2e/programmatic-cli.spec.js
@@ -8,7 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-const { CliRunner, request, wait, TimeCounter, fixturesFolder } = require("./utils");
+const { CliRunner, request, wait, TimeCounter, fixturesFolder } = require("./support/utils");
 
 describe("programmatic Cli", () => {
   const cwdPath = fixturesFolder("programmatic-cli");

--- a/test/e2e/programmatic-server.spec.js
+++ b/test/e2e/programmatic-server.spec.js
@@ -8,7 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-const { CliRunner, request, wait, TimeCounter, fixturesFolder } = require("./utils");
+const { CliRunner, request, wait, TimeCounter, fixturesFolder } = require("./support/utils");
 
 describe("programmatic Server", () => {
   const cwdPath = fixturesFolder("programmatic-server");

--- a/test/e2e/support/CliRunner.js
+++ b/test/e2e/support/CliRunner.js
@@ -32,6 +32,7 @@ module.exports = class CliRunner {
     this._cwd = options.cwd || process.cwd();
     this._debug = options.debug === true;
     this._logs = [];
+    this._currentScreenLogs = [];
     this._allLogs = [];
     this.logData = this.logData.bind(this);
     this.write = this.write.bind(this);
@@ -57,9 +58,11 @@ module.exports = class CliRunner {
   logData(data) {
     if (data.includes(CLRS)) {
       this._eventEmitter.emit(CLEAR_SCREEN_EVENT_NAME, stripAnsi(data.split(CLRS)[1] || ""));
+      this._currentScreenLogs = [];
     }
     const cleanData = stripAnsi(data.replace(/\x1Bc/, ""));
     if (cleanData.length) {
+      this._currentScreenLogs.push(cleanData);
       this._logs.push(cleanData);
       this._allLogs.push(data);
       this._eventEmitter.emit(LOG_EVENT_NAME, cleanData);
@@ -231,6 +234,10 @@ module.exports = class CliRunner {
 
   get logs() {
     return this._logs.join("");
+  }
+
+  get currentScreen() {
+    return this._currentScreenLogs.join("");
   }
 
   get allLogs() {

--- a/test/e2e/support/InteractiveCliRunner.js
+++ b/test/e2e/support/InteractiveCliRunner.js
@@ -11,7 +11,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 const { CliRunner, wait } = require("./utils");
 
 const LOG = "[CLI]: ";
-const SCREEN_SEPARATOR = ">> Mocks server";
 
 module.exports = class InteractiveCliRunner {
   constructor(cliArguments, cliOptions) {
@@ -24,11 +23,7 @@ module.exports = class InteractiveCliRunner {
 
   async getCurrentScreen() {
     await wait(500);
-    const allLogs = this._cli.allLogs;
-    const lastLog = allLogs[allLogs.length - 1];
-    return lastLog.includes(SCREEN_SEPARATOR)
-      ? `${SCREEN_SEPARATOR}${lastLog.split(SCREEN_SEPARATOR).pop()}`
-      : lastLog;
+    return this._cli.currentScreen;
   }
 
   async logCurrentScreen() {
@@ -57,6 +52,10 @@ module.exports = class InteractiveCliRunner {
 
   get logs() {
     return this._cli.logs;
+  }
+
+  get currentScreen() {
+    return this._cli.currentScreen;
   }
 
   async cursorDown(number) {

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -12,7 +12,7 @@ const path = require("path");
 
 const requestPromise = require("request-promise");
 const CliRunner = require("./CliRunner"); // TODO, export in CLI package for testing purposes?
-const { Server } = require("../../index");
+const { Server } = require("../../../index");
 
 const SERVER_PORT = 3100;
 const BINARY_PATH = "../../../bin/mocks-server";
@@ -28,7 +28,7 @@ const defaultRequestOptions = {
 };
 
 const fixturesFolder = (folderName) => {
-  return path.resolve(__dirname, "fixtures", folderName);
+  return path.resolve(__dirname, "..", "fixtures", folderName);
 };
 
 const startServer = (mocksPath, options = {}) => {

--- a/test/e2e/web-tutorial-admin-api.spec.js
+++ b/test/e2e/web-tutorial-admin-api.spec.js
@@ -8,7 +8,13 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-const { startServer, stopServer, request, changeBehavior, getBehaviors } = require("./utils");
+const {
+  startServer,
+  stopServer,
+  request,
+  changeBehavior,
+  getBehaviors,
+} = require("./support/utils");
 
 describe("web tutorial", () => {
   let server;

--- a/test/e2e/web-tutorial-cli.spec.js
+++ b/test/e2e/web-tutorial-cli.spec.js
@@ -9,8 +9,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { request, wait, BINARY_PATH } = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+const { request, wait, BINARY_PATH } = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 describe("web tutorial", () => {
   let cli;

--- a/test/e2e/web-tutorial-deprecated-admin-api.spec.js
+++ b/test/e2e/web-tutorial-deprecated-admin-api.spec.js
@@ -14,7 +14,7 @@ const {
   request,
   deprecatedChangeBehavior,
   deprecatedGetBehaviors,
-} = require("./utils");
+} = require("./support/utils");
 
 describe("web tutorial using deprecated admin-api", () => {
   let server;

--- a/test/e2e/web-tutorial-files-watch.spec.js
+++ b/test/e2e/web-tutorial-files-watch.spec.js
@@ -17,8 +17,8 @@ const {
   getBehaviors,
   fixturesFolder,
   wait,
-} = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+} = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 const runTests = (interactiveCli) => {
   describe("When started", () => {

--- a/test/e2e/web-tutorial-json-admin-api.spec.js
+++ b/test/e2e/web-tutorial-json-admin-api.spec.js
@@ -8,7 +8,13 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-const { startServer, stopServer, request, changeBehavior, getBehaviors } = require("./utils");
+const {
+  startServer,
+  stopServer,
+  request,
+  changeBehavior,
+  getBehaviors,
+} = require("./support/utils");
 
 describe("web tutorial", () => {
   let server;

--- a/test/e2e/web-tutorial-json-cli.spec.js
+++ b/test/e2e/web-tutorial-json-cli.spec.js
@@ -9,8 +9,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const path = require("path");
-const { request, wait, BINARY_PATH } = require("./utils");
-const InteractiveCliRunner = require("./InteractiveCliRunner");
+const { request, wait, BINARY_PATH } = require("./support/utils");
+const InteractiveCliRunner = require("./support/InteractiveCliRunner");
 
 describe("web tutorial", () => {
   let cli;


### PR DESCRIPTION
### Added
- test(E2E): Add more start/stop cli plugin E2E tests
- test(E2E): Add alerts E2E tests

### Changed
- Update dependencies
- Update core version to [1.6.0](https://github.com/mocks-server/core/releases/tag/v1.6.0)
- Update plugin-inquirer-cli version to [1.4.1](https://github.com/mocks-server/plugin-inquirer-cli/releases/tag/v1.4.1)
- Update plugin-admin-api version to [1.5.0](https://github.com/mocks-server/plugin-admin-api/releases/tag/v1.5.0)
- test(E2E): Move support files to support folder