### PR TITLE
Plugin Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 # tests
 /coverage
 /mocks
-/test/e2e/fixtures/mocks
-/test/e2e/fixtures/mocks.config.js
+/test/e2e/fixtures/scaffold/mocks
+/test/e2e/fixtures/scaffold/mocks.config.js
 
 # misc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.6.0] - 2021-12-05
 
-### Changed
+### Added
 - feat: Add `@mocks-server/plugin-proxy`. Support route variants of type "proxy"
 
 ## [2.5.0] - 2021-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### Breaking change
 
+## [2.6.0] - 2021-12-05
+
+### Changed
+- feat: Add `@mocks-server/plugin-proxy`. Support route variants of type "proxy"
+
 ## [2.5.0] - 2021-12-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Providing an interactive command line user interface and a REST API for changing
 * __Multiple mocks__: Group different [route variants](https://www.mocks-server.org/docs/get-started-routes) into different [mocks](https://www.mocks-server.org/docs/get-started-mocks). Change the current mock while the server is running using the [interactive command line interface](https://www.mocks-server.org/docs/plugins-inquirer-cli) or the [REST API](https://www.mocks-server.org/docs/plugins-admin-api).
 * __Multiple formats__: Responses can be defined [using `json` or JavaScript files](https://www.mocks-server.org/docs/guides-organizing-files). [Babel](https://babeljs.io/) is also supported, so [ESM modules and TypeScript can also be used](https://www.mocks-server.org/docs/guides-using-babel).
 * __Express middlewares__: Route variants [can be defined as `express` middlewares](https://www.mocks-server.org/docs/guides-using-middlewares).
+* __Proxy routes__: Route variants [can be configured to proxy request to another host](https://github.com/mocks-server/plugin-proxy), and even modify the request or the response.
 * __Multiple interfaces__: Settings can be changed using the [interactive CLI](https://www.mocks-server.org/docs/plugins-inquirer-cli) or the [admin REST API](https://www.mocks-server.org/docs/plugins-admin-api). The CLI is perfect for development, and the API can be used from tests, for example.
 * __Integrations__: Integrations with other tools are available, as the [Cypress plugin](https://www.mocks-server.org/docs/integrations-cypress).
 * __Customizable__: You can [develop your own plugins](https://www.mocks-server.org/docs/plugins-developing-plugins), or even [routes handlers](https://www.mocks-server.org/docs/api-routes-handler), that allows to customize the format in which route variants are defined.
@@ -84,6 +85,16 @@ module.exports = [
         }
       },
       {
+        id: "one-user", // id of the variant
+        response: {
+          status: 200, // status to send
+          body: [{ // body to send
+            id: 1,
+            name: "John Doe"
+          }]
+        }
+      },
+      {
         id: "error", // id of the variant
         response: {
           status: 400, // status to send
@@ -91,6 +102,11 @@ module.exports = [
             message: "Error"
           }
         }
+      },
+      {
+        id: "proxied", // id of the variant
+        handler: "proxy", // Type of route variant handler
+        host: "https://jsonplaceholder.typicode.com/users" // Host for "proxy" variant
       }
     ]
   }
@@ -110,6 +126,11 @@ The server will respond to the requests with the route variants defined in the c
     "id": "users-error", //id of the mock
     "from": "base", //inherits the route variants of "base" mock
     "routesVariants": ["get-users:error"] //get-users route uses another variant
+  },
+  {
+    "id": "users-proxied", //id of the mock
+    "from": "base", //inherits the route variants of "base" mock
+    "routesVariants": ["get-users:proxied"] //get-users route uses another variant
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project provides a mock server that can store and simulate multiple API beh
 
 Providing an interactive command line user interface and a REST API for changing the responses of the API, it is easy to use both for development and testing.
 
+[Read the whole docs in the project's website](https://www.mocks-server.org/)
+
 ### Main features
 
 * __Route variants__: Define many responses for a same [route](https://www.mocks-server.org/docs/get-started-routes).

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -6,6 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["<rootDir>/test/e2e/*.spec.js"],
+  // testMatch: ["<rootDir>/test/e2e/proxy.spec.js"],
   // testMatch: ["<rootDir>/test/e2e/cli-disabled-runtime.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test

--- a/lib/start.js
+++ b/lib/start.js
@@ -12,6 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 "use strict";
 
 const { Core } = require("@mocks-server/core");
+const PluginProxy = require("@mocks-server/plugin-proxy");
 const AdminApi = require("@mocks-server/plugin-admin-api");
 const InquirerCli = require("@mocks-server/plugin-inquirer-cli");
 
@@ -23,7 +24,7 @@ const handleError = (error) => {
 const start = () => {
   try {
     const mocksServer = new Core({
-      plugins: [AdminApi, InquirerCli],
+      plugins: [PluginProxy, AdminApi, InquirerCli],
     });
     return mocksServer.start().catch(handleError);
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@mocks-server/main",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mocks-server/main",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mocks-server/core": "2.5.1",
         "@mocks-server/plugin-admin-api": "2.2.0",
-        "@mocks-server/plugin-inquirer-cli": "2.2.0"
+        "@mocks-server/plugin-inquirer-cli": "2.2.0",
+        "@mocks-server/plugin-proxy": "1.0.2"
       },
       "bin": {
         "mocks-server": "bin/mocks-server"
@@ -1132,6 +1133,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@mocks-server/plugin-proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.2.tgz",
+      "integrity": "sha512-UtvdQYD9Drx44nYO418n9QxkBZaxgZbtM2OY2gQjT794dmJQ/gR8JyxMtfGxkompmBLeT5bSKowJdYH/XBlPsw==",
+      "dependencies": {
+        "express-http-proxy": "1.6.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@mocks-server/core": ">=2.4.0"
       }
     },
     "node_modules/@sideway/address": {
@@ -2476,6 +2491,11 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -2930,6 +2950,32 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-http-proxy": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.3.tgz",
+      "integrity": "sha512-/l77JHcOUrDUX8V67E287VEUQT0lbm71gdGVoodnlWBziarYKgMcpqT7xvh/HM8Jv52phw8Bd8tY+a7QjOr7Yg==",
+      "dependencies": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/express-http-proxy/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/express-http-proxy/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/express-request-id": {
       "version": "1.4.1",
@@ -7582,6 +7628,14 @@
         }
       }
     },
+    "@mocks-server/plugin-proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.2.tgz",
+      "integrity": "sha512-UtvdQYD9Drx44nYO418n9QxkBZaxgZbtM2OY2gQjT794dmJQ/gR8JyxMtfGxkompmBLeT5bSKowJdYH/XBlPsw==",
+      "requires": {
+        "express-http-proxy": "1.6.3"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -8644,6 +8698,11 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -8994,6 +9053,31 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
+    "express-http-proxy": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.3.tgz",
+      "integrity": "sha512-/l77JHcOUrDUX8V67E287VEUQT0lbm71gdGVoodnlWBziarYKgMcpqT7xvh/HM8Jv52phw8Bd8tY+a7QjOr7Yg==",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mocks-server/core": "2.5.1",
         "@mocks-server/plugin-admin-api": "2.2.0",
         "@mocks-server/plugin-inquirer-cli": "2.2.0",
-        "@mocks-server/plugin-proxy": "1.0.2"
+        "@mocks-server/plugin-proxy": "1.0.3"
       },
       "bin": {
         "mocks-server": "bin/mocks-server"
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@mocks-server/plugin-proxy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.2.tgz",
-      "integrity": "sha512-UtvdQYD9Drx44nYO418n9QxkBZaxgZbtM2OY2gQjT794dmJQ/gR8JyxMtfGxkompmBLeT5bSKowJdYH/XBlPsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.3.tgz",
+      "integrity": "sha512-9mBwTJHXKAmYSfs2DWAq3jt2hoUr+qRTyDxGiiUpRhYvXTxZZF6gMf+qd6nUJeUTBoZegaUhcf/I7GaSWkmCIQ==",
       "dependencies": {
         "express-http-proxy": "1.6.3"
       },
@@ -7629,9 +7629,9 @@
       }
     },
     "@mocks-server/plugin-proxy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.2.tgz",
-      "integrity": "sha512-UtvdQYD9Drx44nYO418n9QxkBZaxgZbtM2OY2gQjT794dmJQ/gR8JyxMtfGxkompmBLeT5bSKowJdYH/XBlPsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@mocks-server/plugin-proxy/-/plugin-proxy-1.0.3.tgz",
+      "integrity": "sha512-9mBwTJHXKAmYSfs2DWAq3jt2hoUr+qRTyDxGiiUpRhYvXTxZZF6gMf+qd6nUJeUTBoZegaUhcf/I7GaSWkmCIQ==",
       "requires": {
         "express-http-proxy": "1.6.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/main",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Mock Server supporting multiple route variants and mocks",
   "keywords": [
     "mock",
@@ -43,7 +43,8 @@
   "dependencies": {
     "@mocks-server/core": "2.5.1",
     "@mocks-server/plugin-admin-api": "2.2.0",
-    "@mocks-server/plugin-inquirer-cli": "2.2.0"
+    "@mocks-server/plugin-inquirer-cli": "2.2.0",
+    "@mocks-server/plugin-proxy": "1.0.2"
   },
   "devDependencies": {
     "cross-fetch": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mocks-server/core": "2.5.1",
     "@mocks-server/plugin-admin-api": "2.2.0",
     "@mocks-server/plugin-inquirer-cli": "2.2.0",
-    "@mocks-server/plugin-proxy": "1.0.2"
+    "@mocks-server/plugin-proxy": "1.0.3"
   },
   "devDependencies": {
     "cross-fetch": "3.1.4",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main
-sonar.projectVersion=2.5.0
+sonar.projectVersion=2.6.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/test/e2e/fixtures/proxy/mocks.config.js
+++ b/test/e2e/fixtures/proxy/mocks.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  // options
+  options: {
+    // mock to use on start
+    mock: "base",
+  },
+};

--- a/test/e2e/fixtures/proxy/mocks/mocks.js
+++ b/test/e2e/fixtures/proxy/mocks/mocks.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    id: "base",
+    routesVariants: ["proxy-all:enabled"],
+  },
+  {
+    id: "proxy-disabled",
+    routesVariants: ["proxy-all:disabled"],
+  },
+];

--- a/test/e2e/fixtures/proxy/mocks/routes/proxy.js
+++ b/test/e2e/fixtures/proxy/mocks/routes/proxy.js
@@ -1,0 +1,19 @@
+module.exports = [
+  {
+    id: "proxy-all",
+    url: "*",
+    method: ["GET", "POST", "PATCH", "PUT"],
+    variants: [
+      {
+        id: "enabled",
+        handler: "proxy",
+        host: "http://127.0.0.1:3200",
+        options: {},
+      },
+      {
+        id: "disabled",
+        response: (req, res, next) => next(),
+      },
+    ],
+  },
+];

--- a/test/e2e/proxy.spec.js
+++ b/test/e2e/proxy.spec.js
@@ -37,6 +37,11 @@ describe("scaffold", () => {
       expect(mocks.currentScreen).toEqual(expect.stringContaining("Mocks: 2"));
     });
 
+    it("should not display alerts", async () => {
+      console.log(mocks.currentScreen);
+      expect(mocks.currentScreen).toEqual(expect.not.stringContaining("ALERTS"));
+    });
+
     it("should serve users collection mock under the /api/users path", async () => {
       const users = await fetch("/api/users");
       expect(users.body).toEqual([

--- a/test/e2e/proxy.spec.js
+++ b/test/e2e/proxy.spec.js
@@ -1,0 +1,208 @@
+/*
+Copyright 2021 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const {
+  mocksRunner,
+  fetch,
+  waitForServerAndCli,
+  wait,
+  fixturesFolder,
+} = require("./support/helpers");
+
+describe("scaffold", () => {
+  jest.setTimeout(15000);
+  let mocks, host;
+
+  beforeAll(async () => {
+    host = mocksRunner(["--port=3200"]);
+    mocks = mocksRunner(["--port=3100"], { cwd: fixturesFolder("proxy") });
+    await waitForServerAndCli();
+    await waitForServerAndCli(3200);
+  });
+
+  afterAll(async () => {
+    await host.kill();
+    await mocks.kill();
+  });
+
+  describe("When started", () => {
+    it("should have 2 mocks available", async () => {
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Mocks: 2"));
+    });
+
+    it("should serve users collection mock under the /api/users path", async () => {
+      const users = await fetch("/api/users");
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await fetch("/api/users/1");
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+
+    it("should serve user 1 under the /api/users/2 path", async () => {
+      const users = await fetch("/api/users/2");
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+  });
+
+  describe("mocks api", () => {
+    it("should return mocks", async () => {
+      const response = await fetch("/admin/mocks");
+      expect(response.body).toEqual([
+        {
+          id: "base",
+          from: null,
+          routesVariants: ["proxy-all:enabled"],
+          appliedRoutesVariants: ["proxy-all:enabled"],
+        },
+        {
+          id: "proxy-disabled",
+          from: null,
+          routesVariants: ["proxy-all:disabled"],
+          appliedRoutesVariants: ["proxy-all:disabled"],
+        },
+      ]);
+    });
+  });
+
+  describe("routes api", () => {
+    it("should return routes", async () => {
+      const response = await fetch("/admin/routes");
+      expect(response.body).toEqual([
+        {
+          id: "proxy-all",
+          url: "*",
+          delay: null,
+          method: ["GET", "POST", "PATCH", "PUT"],
+          variants: ["proxy-all:enabled", "proxy-all:disabled"],
+        },
+      ]);
+    });
+  });
+
+  describe("routes variants api", () => {
+    it("should return routes variants", async () => {
+      const response = await fetch("/admin/routes-variants");
+      expect(response.body).toEqual([
+        {
+          id: "proxy-all:enabled",
+          routeId: "proxy-all",
+          handler: "proxy",
+          response: {
+            host: "http://127.0.0.1:3200",
+          },
+          delay: null,
+        },
+        {
+          id: "proxy-all:disabled",
+          routeId: "proxy-all",
+          handler: "default",
+          response: "function",
+          delay: null,
+        },
+      ]);
+    });
+  });
+
+  describe('When changing current mock to "disabled"', () => {
+    it("should display new selected mock", async () => {
+      await mocks.pressEnter();
+      await mocks.cursorDown(1);
+      const newScreen = await mocks.pressEnter();
+      expect(newScreen).toEqual(expect.stringContaining("Current mock: proxy-disabled"));
+    });
+
+    it("should return not found for /api/users path", async () => {
+      const usersResponse = await fetch("/api/users");
+      expect(usersResponse.status).toEqual(404);
+    });
+
+    it("should return not found for /api/users/2 path", async () => {
+      const usersResponse = await fetch("/api/users/2");
+      expect(usersResponse.status).toEqual(404);
+    });
+  });
+
+  describe("When setting custom route variant", () => {
+    it("should display custom route variant", async () => {
+      await mocks.cursorDown();
+      await mocks.pressEnter();
+      await mocks.cursorDown(2);
+      const newScreen = await mocks.pressEnter();
+      expect(newScreen).toEqual(
+        expect.stringContaining(
+          "Current mock: proxy-disabled (custom variants: proxy-all:enabled)"
+        )
+      );
+    });
+
+    it("should serve users collection mock under the /api/users path", async () => {
+      const users = await fetch("/api/users");
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await fetch("/api/users/1");
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+  });
+
+  describe("when using api to restore routes variants", () => {
+    beforeAll(async () => {
+      await fetch("/admin/mock-custom-routes-variants", {
+        method: "DELETE",
+      });
+    });
+
+    it("should not display custom route variant in CLI", async () => {
+      await wait(500);
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Current mock: proxy-disabled"));
+      expect(mocks.currentScreen).toEqual(expect.not.stringContaining("(custom variants:"));
+    });
+
+    it("should return custom route variants in API", async () => {
+      const response = await fetch("/admin/mock-custom-routes-variants");
+      expect(response.body).toEqual([]);
+    });
+
+    it("should return not found for /api/users path", async () => {
+      const usersResponse = await fetch("/api/users");
+      expect(usersResponse.status).toEqual(404);
+    });
+  });
+
+  describe("when using api to change current mock", () => {
+    beforeAll(async () => {
+      await fetch("/admin/settings", {
+        method: "PATCH",
+        body: {
+          mock: "base",
+        },
+      });
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await fetch("/api/users/1");
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+
+    it("should display new mock in CLI", async () => {
+      await wait(500);
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Current mock: base"));
+    });
+  });
+});

--- a/test/e2e/scaffold.spec.js
+++ b/test/e2e/scaffold.spec.js
@@ -32,6 +32,11 @@ describe("scaffold", () => {
       expect(mocks.currentScreen).toEqual(expect.not.stringContaining("behaviors"));
     });
 
+    it("should not display alerts", async () => {
+      console.log(mocks.currentScreen);
+      expect(mocks.currentScreen).toEqual(expect.not.stringContaining("ALERTS"));
+    });
+
     it("should serve users collection mock under the /api/users path", async () => {
       const users = await fetch("/api/users");
       expect(users.body).toEqual([

--- a/test/e2e/scaffold.spec.js
+++ b/test/e2e/scaffold.spec.js
@@ -32,11 +32,6 @@ describe("scaffold", () => {
       expect(mocks.currentScreen).toEqual(expect.not.stringContaining("behaviors"));
     });
 
-    it("should not display alerts", async () => {
-      console.log(mocks.currentScreen);
-      expect(mocks.currentScreen).toEqual(expect.not.stringContaining("ALERTS"));
-    });
-
     it("should serve users collection mock under the /api/users path", async () => {
       const users = await fetch("/api/users");
       expect(users.body).toEqual([

--- a/test/e2e/support/helpers.js
+++ b/test/e2e/support/helpers.js
@@ -15,7 +15,7 @@ const waitOn = require("wait-on");
 
 const InteractiveCliRunner = require("./InteractiveCliRunner");
 
-const DEFAULT_BINARY_PATH = "../../../bin/mocks-server";
+const DEFAULT_BINARY_PATH = "../../../../bin/mocks-server";
 
 const SERVER_PORT = 3100;
 
@@ -26,12 +26,14 @@ const defaultRequestOptions = {
   },
 };
 
-const defaultMocksRunnerOptions = {
-  cwd: path.resolve(__dirname, "..", "fixtures"),
-};
+const baseFixturesFolder = path.resolve(__dirname, "..", "fixtures");
 
 const fixturesFolder = (folderName) => {
-  return path.resolve(__dirname, "..", "fixtures", folderName);
+  return path.resolve(baseFixturesFolder, folderName);
+};
+
+const defaultMocksRunnerOptions = {
+  cwd: fixturesFolder("scaffold"),
 };
 
 const serverUrl = (port) => {
@@ -94,10 +96,6 @@ const waitForServer = (port) => {
   return waitOn({ resources: [`tcp:127.0.0.1:${port || SERVER_PORT}`] });
 };
 
-const waitForServerUrl = (url) => {
-  return waitOn({ resources: [`${serverUrl()}${url}`] });
-};
-
 const waitForServerAndCli = async (port) => {
   await waitForServer(port);
   await wait();
@@ -122,7 +120,6 @@ module.exports = {
   mocksRunner,
   wait,
   waitForServer,
-  waitForServerUrl,
   waitForServerAndCli,
   fixturesFolder,
 };

--- a/test/unit/start.spec.js
+++ b/test/unit/start.spec.js
@@ -10,6 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 const sinon = require("sinon");
+const PluginProxy = require("@mocks-server/plugin-proxy");
 const AdminApi = require("@mocks-server/plugin-admin-api");
 const InquirerCli = require("@mocks-server/plugin-inquirer-cli");
 
@@ -32,10 +33,10 @@ describe("start method", () => {
     coreMocks.restore();
   });
 
-  it("should create a new Core, passing to it AdminApi and CLI plugins", async () => {
+  it("should create a new Core, passing to it Proxy, AdminApi and CLI plugins", async () => {
     await start();
     expect(coreMocks.stubs.Constructor.mock.calls[0][0]).toEqual({
-      plugins: [AdminApi, InquirerCli],
+      plugins: [PluginProxy, AdminApi, InquirerCli],
     });
   });
 


### PR DESCRIPTION
### Added
- feat: Add `@mocks-server/plugin-proxy`. Support route variants of type "proxy"