### PR TITLE
YAML support. Files API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Node.js mock server running live, interactive mocks in place of real APIs. __It 
 
 ## Usage
 
-Define your mocked API routes in JSON, JavaScript or TypeScript files. Mocks Server loads them automatically and watches for changes. Defining routes using any of the available APIs is also possible.
+Define your mocked API routes in YAML, JSON, JavaScript or TypeScript files. Mocks Server loads them automatically and watches for changes. Defining routes using any of the available APIs is also possible.
 
-Routes can be defined in many ways, from plain objects to Express middlewares, and they can act in different ways also, from sending a response to proxy the request to another host.
+Routes can be defined in many ways, from plain objects to plain text and even Express middlewares, and they can act in different ways also, from sending a response to proxy the request to another host.
 
 ## Configuration
 

--- a/packages/admin-api-client/package.json
+++ b/packages/admin-api-client/package.json
@@ -33,7 +33,7 @@
     "build": "tsc && rollup --config",
     "mocks:ci": "pnpm -w run nx start admin-api-client-unit-mocks",
     "test": "jest --runInBand",
-    "test:unit": "start-server-and-test mocks:ci tcp:127.0.0.1:3200 test"
+    "test:unit": "start-server-and-test mocks:ci tcp:127.0.0.1:3110 test"
   },
   "dependencies": {
     "@mocks-server/admin-api-paths": "workspace:*",

--- a/packages/admin-api-client/test/client.spec.js
+++ b/packages/admin-api-client/test/client.spec.js
@@ -60,7 +60,8 @@ describe("AdminApiClient class", () => {
         const alertId = alerts[1].id;
         const alert = await apiClient.readAlert(alertId);
         expect(alert.id).toEqual(alertId);
-        expect(alert.message).toEqual(expect.stringContaining("Error loading collections"));
+        expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+        expect(alert.message).toEqual(expect.stringContaining("collections.js"));
       });
     });
 

--- a/packages/admin-api-client/test/index.spec.js
+++ b/packages/admin-api-client/test/index.spec.js
@@ -66,7 +66,8 @@ describe("admin api client global methods", () => {
         const alertId = alerts[1].id;
         const alert = await readAlert(alertId);
         expect(alert.id).toEqual(alertId);
-        expect(alert.message).toEqual(expect.stringContaining("Error loading collections"));
+        expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+        expect(alert.message).toEqual(expect.stringContaining("collections.js"));
       });
     });
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [unreleased]
+
+### Changed
+
+- refactor(#371): Separate logic about loading files from logic about loading routes and collections from files. Add `createLoader` method to files. Use the method to create routes and collections loaders.
+
 ## [3.8.0] - 2022-08-04
 
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -14,7 +14,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- refactor(#371): Separate logic about loading files from logic about loading routes and collections from files. Add `createLoader` method to files. Use the method to create routes and collections loaders.
+- refactor(#371): Separate logic about loading files from logic about loading routes and collections from files. Use the new `files.createLoader` method to create routes and collections loaders.
+
+### Added
+- feat: Expose files API in core.
+- feat: Add `createLoader` method to files.
+- feat: Add `reload` method to files.
+
+### Fixed
+- fix: Debounce time in files reload aw not working. Now it has 200ms of debounce, with a maximum time wait of 1000ms
 
 ## [3.8.0] - 2022-08-04
 

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/mock/helpers.spec.js"],
+  // testMatch: ["<rootDir>/test/files/FilesLoaders.spec.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,8 @@
     "node-watch": "0.7.3",
     "update-notifier": "5.1.0",
     "winston": "3.8.1",
-    "winston-array-transport": "1.1.10"
+    "winston-array-transport": "1.1.10",
+    "yaml": "2.1.1"
   },
   "engines": {
     "node": ">=14.x"

--- a/packages/core/src/Core.js
+++ b/packages/core/src/Core.js
@@ -508,6 +508,10 @@ class Core {
     return this._variantHandlers;
   }
 
+  get files() {
+    return this._filesLoader;
+  }
+
   get version() {
     return version;
   }

--- a/packages/core/src/common/CoreApi.js
+++ b/packages/core/src/common/CoreApi.js
@@ -110,6 +110,10 @@ class CoreApi {
     return this._core.server;
   }
 
+  get files() {
+    return this._core.files;
+  }
+
   get mock() {
     return this._core.mock;
   }

--- a/packages/core/src/files/FilesLoaders.js
+++ b/packages/core/src/files/FilesLoaders.js
@@ -261,11 +261,14 @@ class FilesLoaders {
       this._watcher = watch(
         this._path,
         { recursive: true },
-        debounce(() => {
-          this._logger.info("File change detected");
-          this._loadFiles();
-        }),
-        1000
+        debounce(
+          () => {
+            this._logger.info("File change detected");
+            this._loadFiles();
+          },
+          200,
+          { maxWait: 1000 }
+        )
       );
     }
   }

--- a/packages/core/src/files/FilesLoaders.js
+++ b/packages/core/src/files/FilesLoaders.js
@@ -19,7 +19,12 @@ const CollectionsLoader = require("./loaders/Collections");
 const RoutesLoader = require("./loaders/Routes");
 const Loader = require("./Loader");
 
-const { babelRegisterDefaultOptions, getFilesGlobule } = require("./helpers");
+const {
+  babelRegisterDefaultOptions,
+  getFilesGlobule,
+  isYamlFile,
+  readYamlFile,
+} = require("./helpers");
 
 const OPTIONS = [
   {
@@ -125,6 +130,11 @@ class FilesLoaders {
   }
 
   _readFile(filePath) {
+    if (isYamlFile(filePath)) {
+      this._logger.debug(`Loading yaml file ${filePath}`);
+      return readYamlFile(filePath);
+    }
+    this._logger.debug(`Loading file ${filePath}`);
     const content = this._require(filePath);
     return (content && content.default) || content;
   }
@@ -205,7 +215,6 @@ class FilesLoaders {
 
     const filesDetails = filesToLoad
       .map((filePath) => {
-        this._logger.debug(`Loading file ${filePath}`);
         try {
           const fileContent = this._readFile(filePath);
           return {

--- a/packages/core/src/files/FilesLoaders.js
+++ b/packages/core/src/files/FilesLoaders.js
@@ -100,10 +100,12 @@ class FilesLoaders {
     this._collectionsLoader = new CollectionsLoader({
       loadCollections: this._loadCollections,
       createLoader: this.createLoader,
+      getBasePath: this._getPath.bind(this),
     });
     this._routesLoader = new RoutesLoader({
       loadRoutes: this._loadRoutes,
       createLoader: this.createLoader,
+      getBasePath: this._getPath.bind(this),
     });
     this._enabled = this._enabledOption.value;
     if (this._enabled) {
@@ -242,7 +244,10 @@ class FilesLoaders {
     ).then((filesDetails) => {
       const loadedFiles = filesDetails.filter((fileDetails) => !!fileDetails.content);
       const erroredFiles = filesDetails.filter((fileDetails) => !!fileDetails.error);
-      const loadProcess = loader.load(loadedFiles, erroredFiles);
+      const loadProcess = loader.load(loadedFiles, erroredFiles, {
+        alerts: loader.alerts,
+        logger: loader.logger,
+      });
       if (isPromise(loadProcess)) {
         return loadProcess.catch((error) => {
           this._alertsLoad.set(loader.id, `Error proccesing loaded files`, error);
@@ -294,7 +299,6 @@ class FilesLoaders {
       logger: this._loggerLoaders.namespace(id),
       src,
       onLoad,
-      getRootPath: this._getPath.bind(this),
     });
     return this._loaders[id];
   }

--- a/packages/core/src/files/Loader.js
+++ b/packages/core/src/files/Loader.js
@@ -1,0 +1,36 @@
+class Loader {
+  constructor({ id, alerts, logger, src, onLoad, getRootPath }) {
+    this._id = id;
+    this._logger = logger;
+    this._alerts = alerts;
+    this._src = src;
+    this._onLoad = onLoad;
+    this._getRootPath = getRootPath;
+  }
+
+  load(filesContents, fileErrors) {
+    this._onLoad(filesContents, fileErrors);
+  }
+
+  get logger() {
+    return this._logger;
+  }
+
+  get alerts() {
+    return this._alerts;
+  }
+
+  get basePath() {
+    return this._getRootPath();
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  get src() {
+    return this._src;
+  }
+}
+
+module.exports = Loader;

--- a/packages/core/src/files/Loader.js
+++ b/packages/core/src/files/Loader.js
@@ -9,7 +9,7 @@ class Loader {
   }
 
   load(filesContents, fileErrors) {
-    this._onLoad(filesContents, fileErrors);
+    return this._onLoad(filesContents, fileErrors);
   }
 
   get logger() {

--- a/packages/core/src/files/Loader.js
+++ b/packages/core/src/files/Loader.js
@@ -1,15 +1,14 @@
 class Loader {
-  constructor({ id, alerts, logger, src, onLoad, getRootPath }) {
+  constructor({ id, alerts, logger, src, onLoad }) {
     this._id = id;
     this._logger = logger;
     this._alerts = alerts;
     this._src = src;
     this._onLoad = onLoad;
-    this._getRootPath = getRootPath;
   }
 
-  load(filesContents, fileErrors) {
-    return this._onLoad(filesContents, fileErrors);
+  load(filesContents, fileErrors, tools) {
+    return this._onLoad(filesContents, fileErrors, tools);
   }
 
   get logger() {
@@ -18,10 +17,6 @@ class Loader {
 
   get alerts() {
     return this._alerts;
-  }
-
-  get basePath() {
-    return this._getRootPath();
   }
 
   get id() {

--- a/packages/core/src/files/helpers.js
+++ b/packages/core/src/files/helpers.js
@@ -80,8 +80,9 @@ function isYamlFile(filePath) {
 }
 
 function readYamlFile(filePath) {
-  const fileContent = fsExtra.readFileSync(filePath, "utf8");
-  return yaml.parse(fileContent);
+  return fsExtra.readFile(filePath, "utf8").then((fileContent) => {
+    return yaml.parse(fileContent);
+  });
 }
 
 module.exports = {

--- a/packages/core/src/files/loaders/Collections.js
+++ b/packages/core/src/files/loaders/Collections.js
@@ -17,13 +17,14 @@ function getFileToUse(filesContents) {
 }
 
 class CollectionsLoader {
-  constructor({ loadCollections, createLoader }) {
+  constructor({ loadCollections, createLoader, getBasePath }) {
     this._loader = createLoader({
       id: ID,
       src: [FILE_NAME, LEGACY_FILE_NAME],
       onLoad: this._onLoad.bind(this),
     });
 
+    this._getBasePath = getBasePath;
     this._loadCollections = loadCollections;
     this._logger = this._loader.logger;
     this._alerts = this._loader.alerts;
@@ -37,7 +38,7 @@ class CollectionsLoader {
     if (!filesContents.length && !filesErrors.length) {
       this._alerts.set(
         "not-found",
-        `No collections file was found: '${path.resolve(this._loader.basePath, FILE_NAME)}.*'`
+        `No collections file was found: '${path.resolve(this._getBasePath(), FILE_NAME)}.*'`
       );
     }
 

--- a/packages/core/src/files/loaders/Collections.js
+++ b/packages/core/src/files/loaders/Collections.js
@@ -1,0 +1,78 @@
+const path = require("path");
+
+const { validateFileContent } = require("../helpers");
+
+const ID = "collections";
+const FILE_NAME = "collections";
+const LEGACY_FILE_NAME = "mocks";
+
+function findFile(filesContents, fileName) {
+  return filesContents.find((fileDetails) => {
+    return path.basename(fileDetails.path).startsWith(fileName);
+  });
+}
+
+function getFileToUse(filesContents) {
+  return findFile(filesContents, FILE_NAME) || findFile(filesContents, LEGACY_FILE_NAME);
+}
+
+class CollectionsLoader {
+  constructor({ loadCollections, createLoader }) {
+    this._loader = createLoader({
+      id: ID,
+      src: [FILE_NAME, LEGACY_FILE_NAME],
+      onLoad: this._onLoad.bind(this),
+    });
+
+    this._loadCollections = loadCollections;
+    this._logger = this._loader.logger;
+    this._alerts = this._loader.alerts;
+    this._deprecationAlerts = this._loader.alerts.collection("deprecated");
+  }
+
+  _onLoad(filesContents, filesErrors) {
+    this._alerts.clean();
+    const fileToUse = getFileToUse(filesContents);
+
+    if (!filesContents.length && !filesErrors.length) {
+      this._alerts.set(
+        "not-found",
+        `No collections file was found: '${path.resolve(this._loader.basePath, FILE_NAME)}.*'`
+      );
+    }
+
+    if (fileToUse) {
+      const filePath = fileToUse.path;
+      const fileContent = fileToUse.content;
+      const fileName = path.basename(filePath);
+      // LEGACY, to be removed
+      if (fileName.startsWith(LEGACY_FILE_NAME)) {
+        this._deprecationAlerts.set(
+          LEGACY_FILE_NAME,
+          `Defining collections in '${fileName}' file is deprecated. Please rename it to '${fileName.replace(
+            LEGACY_FILE_NAME,
+            FILE_NAME
+          )}'`
+        );
+      } else {
+        this._deprecationAlerts.remove(LEGACY_FILE_NAME);
+      }
+
+      try {
+        const fileErrors = validateFileContent(fileContent);
+        if (!!fileErrors) {
+          throw new Error(fileErrors);
+        }
+        this._loadCollections(fileContent);
+        this._logger.debug(`Loaded collections from file '${filePath}'`);
+      } catch (error) {
+        this._loadCollections([]);
+        this._alerts.set("error", `Error loading collections from file '${filePath}'`, error);
+      }
+    } else {
+      this._loadCollections([]);
+    }
+  }
+}
+
+module.exports = CollectionsLoader;

--- a/packages/core/src/files/loaders/Routes.js
+++ b/packages/core/src/files/loaders/Routes.js
@@ -8,13 +8,14 @@ const ID = "routes";
 const FOLDER_NAME = "routes";
 
 class RoutesLoader {
-  constructor({ loadRoutes, createLoader }) {
+  constructor({ loadRoutes, createLoader, getBasePath }) {
     this._loader = createLoader({
       id: ID,
       src: `${FOLDER_NAME}/**/*`,
       onLoad: this._onLoad.bind(this),
     });
 
+    this._getBasePath = getBasePath;
     this._loadRoutes = loadRoutes;
     this._logger = this._loader.logger;
     this._alerts = this._loader.alerts;
@@ -44,7 +45,7 @@ class RoutesLoader {
     );
     this._loadRoutes(routes);
     this._logger.verbose(
-      `Loaded routes from folder '${path.resolve(this._loader.basePath, FOLDER_NAME)}'`
+      `Loaded routes from folder '${path.resolve(this._getBasePath(), FOLDER_NAME)}'`
     );
   }
 }

--- a/packages/core/src/files/loaders/Routes.js
+++ b/packages/core/src/files/loaders/Routes.js
@@ -1,0 +1,52 @@
+const path = require("path");
+
+const { flatten } = require("lodash");
+
+const { validateFileContent } = require("../helpers");
+
+const ID = "routes";
+const FOLDER_NAME = "routes";
+
+class RoutesLoader {
+  constructor({ loadRoutes, createLoader }) {
+    this._loader = createLoader({
+      id: ID,
+      src: `${FOLDER_NAME}/**/*`,
+      onLoad: this._onLoad.bind(this),
+    });
+
+    this._loadRoutes = loadRoutes;
+    this._logger = this._loader.logger;
+    this._alerts = this._loader.alerts;
+    this._alertsFiles = this._alerts.collection("file");
+  }
+
+  _onLoad(filesContents) {
+    this._alerts.clean();
+    this._logger.debug(`Loading routes. ${filesContents.length} route files found.`);
+    const routes = flatten(
+      filesContents
+        .map((fileDetails) => {
+          const filePath = fileDetails.path;
+          const fileContent = fileDetails.content;
+
+          const fileErrors = validateFileContent(fileContent);
+          if (!!fileErrors) {
+            this._alertsFiles.set(
+              filePath,
+              `Error loading routes from file ${filePath}: ${fileErrors}`
+            );
+            return null;
+          }
+          return fileContent;
+        })
+        .filter((fileContent) => !!fileContent)
+    );
+    this._loadRoutes(routes);
+    this._logger.verbose(
+      `Loaded routes from folder '${path.resolve(this._loader.basePath, FOLDER_NAME)}'`
+    );
+  }
+}
+
+module.exports = RoutesLoader;

--- a/packages/core/src/variant-handlers/VariantHandlers.js
+++ b/packages/core/src/variant-handlers/VariantHandlers.js
@@ -49,7 +49,7 @@ class VariantHandlers {
 
   _registerOne(VariantHandler) {
     // TODO, check id, etc..
-    this._logger.verbose(`Registering '${VariantHandler.id}' variant handler`);
+    this._logger.debug(`Registering '${VariantHandler.id}' variant handler`);
     this._registeredVariantHandlers.push(VariantHandler);
   }
 

--- a/packages/core/test/Core.mocks.js
+++ b/packages/core/test/Core.mocks.js
@@ -74,6 +74,12 @@ class CoreMock {
         register: this._sandbox.stub(),
       },
       version: "foo-version",
+      files: {
+        start: this._sandbox.stub(),
+        stop: this._sandbox.stub(),
+        reload: this._sandbox.stub(),
+        createLoader: this._sandbox.stub(),
+      },
     };
 
     Core.mockImplementation(() => this._stubs);

--- a/packages/core/test/Core.spec.js
+++ b/packages/core/test/Core.spec.js
@@ -424,4 +424,10 @@ describe("Core", () => {
       expect(core.variantHandlers).toEqual(core._variantHandlers);
     });
   });
+
+  describe("files getter", () => {
+    it("should return files instance", () => {
+      expect(core.files).toEqual(filesLoadersMocks.stubs.instance);
+    });
+  });
 });

--- a/packages/core/test/files/FilesLoaders.spec.js
+++ b/packages/core/test/files/FilesLoaders.spec.js
@@ -143,6 +143,14 @@ describe("FilesLoaders", () => {
     });
   });
 
+  describe("loaders getter", () => {
+    it("should return loaders", async () => {
+      await filesLoader.init();
+      expect(filesLoader.loaders.collections).toBeDefined();
+      expect(filesLoader.loaders.routes).toBeDefined();
+    });
+  });
+
   describe("when initialized", () => {
     it("should not require files from mocks folders if it is disabled", async () => {
       enabledOption.value = false;
@@ -162,7 +170,7 @@ describe("FilesLoaders", () => {
     it("should not throw and add an alert if there is an error loading route files", async () => {
       libsMocks.stubs.globule.find.returns(["foo"]);
       await filesLoader.init();
-      expect(alerts.flat.length).toEqual(2);
+      expect(alerts.flat.length).toEqual(1);
     });
 
     it("should add an alert when a routes file content does not pass validation", async () => {
@@ -176,10 +184,28 @@ describe("FilesLoaders", () => {
       filesLoader._babelRegisterOption = babelRegisterOption;
       filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
       await filesLoader.init();
-      expect(alerts.flat[1].collection).toEqual("files:routes:file");
-      expect(alerts.flat[1].id).toEqual("foo");
-      expect(alerts.flat[1].value.message).toEqual(
+      expect(alerts.flat[0].collection).toEqual("files:loader:routes:file");
+      expect(alerts.flat[0].id).toEqual("foo");
+      expect(alerts.flat[0].value.message).toEqual(
         expect.stringContaining("Error loading routes from file foo")
+      );
+    });
+
+    it("should add an alert when collections file content does not pass validation", async () => {
+      libsMocks.stubs.globule.find.returns(["collections.json"]);
+      filesLoader = new FilesLoaders(pluginMethods, {
+        requireCache,
+        require: () => ({}),
+      });
+      filesLoader._pathOption = pathOption;
+      filesLoader._watchOption = watchOption;
+      filesLoader._babelRegisterOption = babelRegisterOption;
+      filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
+      await filesLoader.init();
+      expect(alerts.flat[0].collection).toEqual("files:loader:collections");
+      expect(alerts.flat[0].id).toEqual("error");
+      expect(alerts.flat[0].value.message).toEqual(
+        expect.stringContaining("Error loading collections from file")
       );
     });
 
@@ -202,7 +228,8 @@ describe("FilesLoaders", () => {
       expect(alerts.flat.length).toEqual(1);
     });
 
-    it("should remove alerts when mocks file loads successfully", async () => {
+    it("should remove alerts when collections file loads successfully", async () => {
+      libsMocks.stubs.globule.find.returns(["foo"]);
       filesLoader = new FilesLoaders(pluginMethods, {
         requireCache,
         require: () => [],
@@ -213,6 +240,23 @@ describe("FilesLoaders", () => {
       filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
       await filesLoader.init();
       expect(alerts.flat.length).toEqual(0);
+    });
+
+    it("should add an alert when no collections file is found", async () => {
+      libsMocks.stubs.globule.find.returns([]);
+      filesLoader = new FilesLoaders(pluginMethods, {
+        requireCache,
+        require: () => [],
+      });
+      filesLoader._pathOption = pathOption;
+      filesLoader._watchOption = watchOption;
+      filesLoader._babelRegisterOption = babelRegisterOption;
+      filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
+      await filesLoader.init();
+      expect(alerts.flat.length).toEqual(1);
+      expect(alerts.flat[0].value.message).toEqual(
+        expect.stringContaining("No collections file was found")
+      );
     });
 
     it("should call to loadCollections method when mocks file is loaded", async () => {
@@ -228,39 +272,39 @@ describe("FilesLoaders", () => {
       expect(pluginMethods.loadCollections.callCount).toEqual(1);
     });
 
-    it("should try to load collections.json when collections.js file does not exists", async () => {
-      filesLoader = new FilesLoaders(pluginMethods, {
-        requireCache,
-        require: sandbox.spy,
-      });
-      filesLoader._pathOption = pathOption;
-      filesLoader._watchOption = watchOption;
-      filesLoader._babelRegisterOption = babelRegisterOption;
-      filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
-      libsMocks.stubs.fsExtra.existsSync.onCall(0).returns(true);
-      libsMocks.stubs.fsExtra.existsSync.onCall(1).returns(false);
-      libsMocks.stubs.fsExtra.existsSync.onCall(2).returns(true);
-      await filesLoader.init();
-      expect(libsMocks.stubs.fsExtra.existsSync.callCount).toEqual(3);
-    });
-
     it("should add an alert when file name is mocks", async () => {
+      libsMocks.stubs.globule.find.returns(["mocks.json"]);
       filesLoader = new FilesLoaders(pluginMethods, {
         requireCache,
-        require: sandbox.spy,
+        require: () => [],
       });
       filesLoader._pathOption = pathOption;
       filesLoader._watchOption = watchOption;
       filesLoader._babelRegisterOption = babelRegisterOption;
       filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
-      libsMocks.stubs.fsExtra.existsSync.onCall(0).returns(true);
-      libsMocks.stubs.fsExtra.existsSync.onCall(1).returns(false);
-      libsMocks.stubs.fsExtra.existsSync.onCall(2).returns(false);
-      libsMocks.stubs.fsExtra.existsSync.onCall(3).returns(true);
       await filesLoader.init();
       expect(alerts.flat[0].value.message).toEqual(
         "Defining collections in 'mocks.json' file is deprecated. Please rename it to 'collections.json'"
       );
+    });
+
+    it("should remove alert when file name is collections", async () => {
+      libsMocks.stubs.globule.find.returns(["mocks.json"]);
+      filesLoader = new FilesLoaders(pluginMethods, {
+        requireCache,
+        require: () => [],
+      });
+      filesLoader._pathOption = pathOption;
+      filesLoader._watchOption = watchOption;
+      filesLoader._babelRegisterOption = babelRegisterOption;
+      filesLoader._babelRegisterOptionsOption = babelRegisterOptionsOption;
+      await filesLoader.init();
+      expect(alerts.flat[0].value.message).toEqual(
+        "Defining collections in 'mocks.json' file is deprecated. Please rename it to 'collections.json'"
+      );
+      libsMocks.stubs.globule.find.returns(["collections.json"]);
+      filesLoader._loadFiles();
+      expect(alerts.flat.length).toEqual(0);
     });
 
     it("should not throw and add an alert if there is an error in loadRoutesfiles method", async () => {

--- a/packages/core/test/files/helpers.spec.js
+++ b/packages/core/test/files/helpers.spec.js
@@ -50,19 +50,25 @@ describe("FilesLoader helpers", () => {
 
   describe("getFilesGlobule", () => {
     it("should return default plugin globules when babelRegister is disabled", () => {
-      expect(getFilesGlobule("**/*", false, {})).toEqual(["**/*.json", "**/*.js"]);
+      expect(getFilesGlobule("**/*", false, {})).toEqual([
+        "**/*.json",
+        "**/*.js",
+        "**/*.yaml",
+        "**/*.yml",
+      ]);
     });
 
     it("should return babel/register globules and default plugin globules when babelRegister is enabled", () => {
       expect(getFilesGlobule("**/*", true, {})).toEqual([
         "**/*.json",
         "**/*.js",
+        "**/*.yaml",
+        "**/*.yml",
         "**/*.es6",
         "**/*.es",
         "**/*.esm",
         "**/*.cjs",
         "**/*.jsx",
-        "**/*.js",
         "**/*.mjs",
         "**/*.ts",
       ]);
@@ -73,7 +79,7 @@ describe("FilesLoader helpers", () => {
         getFilesGlobule("**/*", true, {
           extensions: [".foo", ".foo2"],
         })
-      ).toEqual(["**/*.json", "**/*.js", "**/*.foo", "**/*.foo2"]);
+      ).toEqual(["**/*.json", "**/*.js", "**/*.yaml", "**/*.yml", "**/*.foo", "**/*.foo2"]);
     });
   });
 });

--- a/packages/core/test/files/helpers.spec.js
+++ b/packages/core/test/files/helpers.spec.js
@@ -21,7 +21,16 @@ describe("FilesLoader helpers", () => {
     describe("extensions property", () => {
       it("should return Babel default extensions", () => {
         const options = babelRegisterDefaultOptions("foo/folder", {});
-        expect(options.extensions).toEqual([".es6", ".es", ".jsx", ".js", ".mjs", ".ts"]);
+        expect(options.extensions).toEqual([
+          ".es6",
+          ".es",
+          ".esm",
+          ".cjs",
+          ".jsx",
+          ".js",
+          ".mjs",
+          ".ts",
+        ]);
       });
     });
 
@@ -41,15 +50,17 @@ describe("FilesLoader helpers", () => {
 
   describe("getFilesGlobule", () => {
     it("should return default plugin globules when babelRegister is disabled", () => {
-      expect(getFilesGlobule(false, {})).toEqual(["**/*.json", "**/*.js"]);
+      expect(getFilesGlobule("**/*", false, {})).toEqual(["**/*.json", "**/*.js"]);
     });
 
     it("should return babel/register globules and default plugin globules when babelRegister is enabled", () => {
-      expect(getFilesGlobule(true, {})).toEqual([
+      expect(getFilesGlobule("**/*", true, {})).toEqual([
         "**/*.json",
         "**/*.js",
         "**/*.es6",
         "**/*.es",
+        "**/*.esm",
+        "**/*.cjs",
         "**/*.jsx",
         "**/*.js",
         "**/*.mjs",
@@ -59,7 +70,7 @@ describe("FilesLoader helpers", () => {
 
     it("should return babel/register custom globules and default plugin globules when babelRegisterOptions has custom extensions", () => {
       expect(
-        getFilesGlobule(true, {
+        getFilesGlobule("**/*", true, {
           extensions: [".foo", ".foo2"],
         })
       ).toEqual(["**/*.json", "**/*.js", "**/*.foo", "**/*.foo2"]);

--- a/packages/core/test/plugins/Plugins.spec.js
+++ b/packages/core/test/plugins/Plugins.spec.js
@@ -318,6 +318,17 @@ describe("Plugins", () => {
       expect(version).toEqual("foo-version");
     });
 
+    it("should have core.files available", async () => {
+      const fooPlugin = {
+        register: ({ files }) => {
+          files.reload();
+        },
+      };
+      pluginsOption.value = [fooPlugin];
+      await plugins.register();
+      expect(coreInstance.files.reload.callCount).toEqual(1);
+    });
+
     it("should have core addRouter method available", async () => {
       const fooPlugin = {
         register: ({ addRouter }) => {

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- feat: Trace start error
+### Changed
+- feat: Log possible start errors
+- chore(deps): Update `@mocks-server/core` dependency
 
 ## [3.8.0] - 2022-08-04
 

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### Breaking change
 
+## [unreleased]
+
+- feat: Trace start error
+
 ## [3.8.0] - 2022-08-04
 
 ### Changed

--- a/packages/main/src/start.js
+++ b/packages/main/src/start.js
@@ -15,6 +15,7 @@ const { createCore } = require("./createCore");
 
 const handleError = (error) => {
   console.error(`Error: ${error.message}`);
+  console.log(error);
   process.exitCode = 1;
 };
 

--- a/packages/plugin-admin-api/jest.config.js
+++ b/packages/plugin-admin-api/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/variants-static.spec.js"],
+  // testMatch: ["<rootDir>/test/alerts-api.spec.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node",

--- a/packages/plugin-admin-api/test/alerts-api.spec.js
+++ b/packages/plugin-admin-api/test/alerts-api.spec.js
@@ -97,8 +97,8 @@ describe("alerts api", () => {
 
     it("should return alert containing error", async () => {
       const response = await doApiFetch("/alerts");
-      expect(response.body.length).toEqual(5);
-      expect(response.body[4].error.message).toEqual(
+      expect(response.body.length).toEqual(6);
+      expect(response.body[5].error.message).toEqual(
         expect.stringContaining("Cannot find module '../db/users'")
       );
     });

--- a/packages/plugin-admin-api/test/legacy/alerts-api.spec.js
+++ b/packages/plugin-admin-api/test/legacy/alerts-api.spec.js
@@ -96,8 +96,8 @@ describe("alerts api", () => {
 
     it("should return alert containing error", async () => {
       const response = await doLegacyFetch("/admin/alerts");
-      expect(response.body.length).toEqual(6);
-      expect(response.body[5].error.message).toEqual(
+      expect(response.body.length).toEqual(7);
+      expect(response.body[6].error.message).toEqual(
         expect.stringContaining("Cannot find module '../db/users'")
       );
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,7 @@ importers:
       update-notifier: 5.1.0
       winston: 3.8.1
       winston-array-transport: 1.1.10
+      yaml: 2.1.1
     dependencies:
       '@babel/register': 7.18.9_@babel+core@7.18.10
       '@hapi/boom': 9.1.4
@@ -266,6 +267,7 @@ importers:
       update-notifier: 5.1.0
       winston: 3.8.1
       winston-array-transport: 1.1.10
+      yaml: 2.1.1
 
   packages/cypress-commands:
     specifiers:
@@ -17056,6 +17058,11 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  /yaml/2.1.1:
+    resolution: {integrity: sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /yargs-parser/13.1.2:
     resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}

--- a/test/admin-api-client-nodejs-e2e/src/index.spec.js
+++ b/test/admin-api-client-nodejs-e2e/src/index.spec.js
@@ -74,7 +74,7 @@ describe("admin api client methods", () => {
         const alertId = alerts[2].id;
         const alert = await readAlert(alertId);
         expect(alert.id).toEqual(alertId);
-        expect(alert.message).toEqual(expect.stringContaining("Error loading collections"));
+        expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
       });
     });
 

--- a/test/core-e2e-legacy/src/files-error.spec.js
+++ b/test/core-e2e-legacy/src/files-error.spec.js
@@ -43,9 +43,14 @@ describe("when there is an error loading files", () => {
     });
 
     it("should have added an alert about error loading collections", async () => {
-      expect(findAlert("files:collections", core.alerts).message).toEqual(
-        expect.stringContaining("Error loading collections from file")
-      );
+      const alert = findAlert("files:load:", core.alerts);
+      expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+      expect(alert.message).toEqual(expect.stringContaining("mocks.js"));
+    });
+
+    it("should have not added an alert about no collections file found", async () => {
+      const alert = findAlert("files:loader:collections:not-found", core.alerts);
+      expect(alert).toBe(undefined);
     });
   });
 
@@ -72,9 +77,9 @@ describe("when there is an error loading files", () => {
     });
 
     it("should have added an alert about error loading routes", async () => {
-      expect(findAlert("files:routes", core.alerts).message).toEqual(
-        expect.stringContaining("Error loading routes from folder")
-      );
+      const alert = findAlert("files:load:", core.alerts);
+      expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+      expect(alert.message).toEqual(expect.stringContaining("user.js"));
     });
 
     it("mocks should not have routes variants", () => {

--- a/test/core-e2e-legacy/src/validations.spec.js
+++ b/test/core-e2e-legacy/src/validations.spec.js
@@ -32,7 +32,7 @@ describe("mocks and routes validations", () => {
     });
 
     it("should have added an alert about route file not exporting array", () => {
-      expect(findAlert("files:routes:file:", core.alerts).message).toEqual(
+      expect(findAlert("files:loader:routes:file:", core.alerts).message).toEqual(
         expect.stringContaining("File does not export an array")
       );
     });
@@ -41,8 +41,8 @@ describe("mocks and routes validations", () => {
       expect(core.mocks.plainRoutes.length).toEqual(1);
     });
 
-    it("should have added an alert about mocks file loading error", () => {
-      expect(findAlert("files:collections", core.alerts).error.message).toEqual(
+    it("should have added an alert about collections file loading error", () => {
+      expect(findAlert("files:loader:collections", core.alerts).error.message).toEqual(
         expect.stringContaining("File does not export an array")
       );
     });

--- a/test/core-e2e/jest.config.js
+++ b/test/core-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["<rootDir>/src/**/*.spec.js"],
-  // testMatch: ["<rootDir>/src/**/yaml-files.spec.js"],
+  // testMatch: ["<rootDir>/src/**/files-loaders.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/test/core-e2e/jest.config.js
+++ b/test/core-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["<rootDir>/src/**/*.spec.js"],
-  // testMatch: ["<rootDir>/src/**/file-handler.spec.js"],
+  // testMatch: ["<rootDir>/src/**/validations.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/test/core-e2e/jest.config.js
+++ b/test/core-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   testMatch: ["<rootDir>/src/**/*.spec.js"],
-  // testMatch: ["<rootDir>/src/**/validations.spec.js"],
+  // testMatch: ["<rootDir>/src/**/yaml-files.spec.js"],
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: false,

--- a/test/core-e2e/src/files-error.spec.js
+++ b/test/core-e2e/src/files-error.spec.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Javier Brea
+Copyright 2021-2022 Javier Brea
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
@@ -43,9 +43,14 @@ describe("when there is an error loading files", () => {
     });
 
     it("should have added an alert about error loading collections", async () => {
-      expect(findAlert("files:collections", core.alerts).message).toEqual(
-        expect.stringContaining("Error loading collections from file")
-      );
+      const alert = findAlert("files:load:", core.alerts);
+      expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+      expect(alert.message).toEqual(expect.stringContaining("collections.js"));
+    });
+
+    it("should have not added an alert about no collections file found", async () => {
+      const alert = findAlert("files:loader:collections:not-found", core.alerts);
+      expect(alert).toBe(undefined);
     });
   });
 
@@ -72,9 +77,9 @@ describe("when there is an error loading files", () => {
     });
 
     it("should have added an alert about error loading routes", async () => {
-      expect(findAlert("files:routes", core.alerts).message).toEqual(
-        expect.stringContaining("Error loading routes from folder")
-      );
+      const alert = findAlert("files:load:", core.alerts);
+      expect(alert.message).toEqual(expect.stringContaining("Error loading file"));
+      expect(alert.message).toEqual(expect.stringContaining("user.js"));
     });
 
     it("collections should not have routes", () => {

--- a/test/core-e2e/src/files-loaders.spec.js
+++ b/test/core-e2e/src/files-loaders.spec.js
@@ -1,0 +1,128 @@
+/*
+Copyright 2022 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+const path = require("path");
+const fsExtra = require("fs-extra");
+const { flatten } = require("lodash");
+const {
+  doFetch,
+  fixturesFolder,
+  waitForServer,
+  wait,
+  removeConfigFile,
+  startCore,
+} = require("./support/helpers");
+
+describe("when files watch is disabled", () => {
+  let core;
+
+  beforeAll(async () => {
+    await fsExtra.remove(fixturesFolder("temp"));
+    await fsExtra.copy(fixturesFolder("yaml-files"), fixturesFolder("temp"));
+    await fsExtra.move(
+      path.resolve(fixturesFolder("temp"), "routes"),
+      path.resolve(fixturesFolder("temp"), "custom-routes")
+    );
+    core = await startCore("temp", {
+      files: {
+        watch: false,
+      },
+    });
+    const { loadRoutes } = core.mock.createLoaders();
+
+    core.files.createLoader({
+      id: "custom-routes",
+      src: `custom-routes/**/*`,
+      onLoad: (filesContents, _errors, { logger }) => {
+        const routes = flatten(
+          filesContents
+            .map((fileDetails) => {
+              return Array.isArray(fileDetails.content) ? fileDetails.content : null;
+            })
+            .filter((fileContent) => !!fileContent)
+        );
+        loadRoutes(routes);
+        logger.verbose(`Loaded routes from folder "${core.files.path}/custom-routes"`);
+      },
+    });
+    await core.files.reload();
+    await waitForServer();
+  });
+
+  afterAll(async () => {
+    removeConfigFile();
+    await fsExtra.remove(fixturesFolder("temp"));
+    await core.stop();
+  });
+
+  describe("When started", () => {
+    it("should serve users under the /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await doFetch("/api/users/1");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+
+    it("should serve user 1 under the /api/users/2 path", async () => {
+      const users = await doFetch("/api/users/2");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+  });
+
+  describe("When files are modified", () => {
+    beforeAll(async () => {
+      await fsExtra.copy(fixturesFolder("web-tutorial-modified"), fixturesFolder("temp"));
+      await fsExtra.remove(path.resolve(fixturesFolder("temp"), "custom-routes"));
+      await wait(4000);
+    });
+
+    it("should serve users in /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+  });
+
+  describe("When files are reloaded", () => {
+    beforeAll(async () => {
+      await core.files.reload();
+      await wait(4000);
+    });
+
+    it("should serve users modified in /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.headers.get("x-custom-header")).toEqual("foo-header");
+      expect(users.headers.get("x-another-header")).toEqual("another-header");
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe modified" },
+        { id: 2, name: "Jane Doe modified" },
+      ]);
+    });
+
+    it("should serve new users in /api/new-users path", async () => {
+      const users = await doFetch("/api/new-users");
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe modified" },
+        { id: 2, name: "Jane Doe modified" },
+        { id: 3, name: "Brand new user" },
+      ]);
+    });
+  });
+});

--- a/test/core-e2e/src/fixtures/web-tutorial-modified/routes/foo.js
+++ b/test/core-e2e/src/fixtures/web-tutorial-modified/routes/foo.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/test/core-e2e/src/fixtures/yaml-files/collections.yml
+++ b/test/core-e2e/src/fixtures/yaml-files/collections.yml
@@ -1,0 +1,8 @@
+- id: "base"
+  routes:
+    - "get-users:success"
+    - "get-user:1"
+- id: "user-2"
+  from: "base"
+  routes:
+    - "get-user:2"

--- a/test/core-e2e/src/fixtures/yaml-files/routes/users.yaml
+++ b/test/core-e2e/src/fixtures/yaml-files/routes/users.yaml
@@ -1,0 +1,37 @@
+- id: "get-users"
+  url: "/api/users"
+  method: "GET"
+  variants:
+    - id: "success"
+      type: "json"
+      options:
+        status: 200
+        body:
+          - id: 1
+            name: "John Doe"
+          - id: 2
+            name: "Jane Doe"
+    - id: "error"
+      type": "json"
+      options:
+        status: 403
+        body:
+          message: "Bad data"
+- id: "get-user"
+  url: "/api/users/:id"
+  method: "GET"
+  variants:
+    - id: "1"
+      type: "json"
+      options:
+        status: 200
+        body:
+          id: 1
+          name: "John Doe"
+    - id: "2"
+      type: "json"
+      options:
+        status: 200
+        body:
+          id: 2
+          name: "Jane Doe"

--- a/test/core-e2e/src/validations.spec.js
+++ b/test/core-e2e/src/validations.spec.js
@@ -32,7 +32,7 @@ describe("mocks and routes validations", () => {
     });
 
     it("should have added an alert about route file not exporting array", () => {
-      expect(findAlert("files:routes:file:", core.alerts).message).toEqual(
+      expect(findAlert("files:loader:routes:file:", core.alerts).message).toEqual(
         expect.stringContaining("File does not export an array")
       );
     });
@@ -41,8 +41,8 @@ describe("mocks and routes validations", () => {
       expect(core.mock.routes.plain.length).toEqual(1);
     });
 
-    it("should have added an alert about mocks file loading error", () => {
-      expect(findAlert("files:collections", core.alerts).error.message).toEqual(
+    it("should have added an alert about collections file loading error", () => {
+      expect(findAlert("files:loader:collections", core.alerts).error.message).toEqual(
         expect.stringContaining("File does not export an array")
       );
     });

--- a/test/core-e2e/src/yaml-files.spec.js
+++ b/test/core-e2e/src/yaml-files.spec.js
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 Javier Brea
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const {
+  startCore,
+  doFetch,
+  waitForServer,
+  findAlert,
+  removeConfigFile,
+} = require("./support/helpers");
+
+describe("json files", () => {
+  let core, changeCollection;
+
+  beforeAll(async () => {
+    core = await startCore("yaml-files");
+    await waitForServer();
+    changeCollection = (name) => {
+      core.config.namespace("mock").namespace("collections").option("selected").value = name;
+    };
+  });
+
+  afterAll(async () => {
+    removeConfigFile();
+    await core.stop();
+  });
+
+  describe("collection by default", () => {
+    it("should have added an alert about collection was not defined", () => {
+      expect(findAlert("mock:collections:selected", core.alerts).message).toEqual(
+        expect.stringContaining("Option 'mock.collections.selected' was not defined")
+      );
+    });
+
+    it("should serve users under the /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await doFetch("/api/users/1");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+
+    it("should serve user 1 under the /api/users/2 path", async () => {
+      const users = await doFetch("/api/users/2");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+  });
+
+  describe('when changing collection to "user-2"', () => {
+    beforeAll(() => {
+      changeCollection("user-2");
+    });
+
+    it("should have removed alert", () => {
+      expect(findAlert("mock:collections:selected", core.alerts)).toEqual(undefined);
+    });
+
+    it("should serve users collection under the /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 2 under the /api/users/1 path", async () => {
+      const users = await doFetch("/api/users/1");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 2, name: "Jane Doe" });
+    });
+
+    it("should serve user 2 under the /api/users/2 path", async () => {
+      const users = await doFetch("/api/users/2");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 2, name: "Jane Doe" });
+    });
+  });
+
+  describe('when changing collection to "foo"', () => {
+    beforeAll(() => {
+      changeCollection("foo");
+    });
+
+    it("should have added an alert", () => {
+      expect(findAlert("mock:collections:selected", core.alerts).message).toEqual(
+        expect.stringContaining("Collection 'foo' was not found")
+      );
+    });
+
+    // if collection not exists, it uses the first one found
+    it("should serve users under the /api/users path", async () => {
+      const users = await doFetch("/api/users");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual([
+        { id: 1, name: "John Doe" },
+        { id: 2, name: "Jane Doe" },
+      ]);
+    });
+
+    it("should serve user 1 under the /api/users/1 path", async () => {
+      const users = await doFetch("/api/users/1");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+
+    it("should serve user 1 under the /api/users/2 path", async () => {
+      const users = await doFetch("/api/users/2");
+      expect(users.status).toEqual(200);
+      expect(users.body).toEqual({ id: 1, name: "John Doe" });
+    });
+  });
+});

--- a/test/plugin-inquirer-cli-e2e/src/main/files-watch.spec.js
+++ b/test/plugin-inquirer-cli-e2e/src/main/files-watch.spec.js
@@ -15,7 +15,6 @@ const {
   waitForServerAndCli,
   wait,
   fixturesFolder,
-  pathJoin,
 } = require("./support/helpers");
 
 describe("files watcher", () => {
@@ -164,13 +163,9 @@ describe("files watcher", () => {
       expect(mocks.currentScreen).toEqual(expect.stringContaining("Error: [files:load"));
       expect(mocks.currentScreen).toEqual(expect.stringContaining("Error loading file"));
       expect(mocks.currentScreen).toEqual(
-        expect.stringContaining(
-          `${pathJoin("main", "fixtures", "temp", "collections.js")}: foo is not defined`
-        )
+        expect.stringContaining(`collections.js: foo is not defined`)
       );
-      expect(mocks.currentScreen).toEqual(
-        expect.stringContaining(`${pathJoin("main", "fixtures", "temp", "collections.js")}:11:18`)
-      );
+      expect(mocks.currentScreen).toEqual(expect.stringContaining(`collections.js:11:18`));
     });
 
     it("should have no mocks available", async () => {

--- a/test/plugin-inquirer-cli-e2e/src/main/files-watch.spec.js
+++ b/test/plugin-inquirer-cli-e2e/src/main/files-watch.spec.js
@@ -161,11 +161,8 @@ describe("files watcher", () => {
     });
 
     it("should display an error", async () => {
-      expect(mocks.currentScreen).toEqual(
-        expect.stringContaining(
-          "Error: [files:collections:error] Error loading collections from file"
-        )
-      );
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Error: [files:load"));
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Error loading file"));
       expect(mocks.currentScreen).toEqual(
         expect.stringContaining(
           `${pathJoin("main", "fixtures", "temp", "collections.js")}: foo is not defined`
@@ -212,20 +209,17 @@ describe("files watcher", () => {
       expect.assertions(2);
       expect(mocks.currentScreen).toEqual(expect.not.stringContaining("ALERTS"));
       expect(mocks.currentScreen).toEqual(
-        expect.stringContaining("Error loading collections from file")
+        expect.stringContaining("[error][alerts:load] Error loading file")
       );
     });
 
     it("should display alerts when exit logs mode", async () => {
-      expect.assertions(3);
+      expect.assertions(4);
       await mocks.pressEnter();
       await wait(2000);
       expect(mocks.currentScreen).toEqual(expect.not.stringContaining("Displaying logs"));
-      expect(mocks.currentScreen).toEqual(
-        expect.stringContaining(
-          "Error: [files:collections:error] Error loading collections from file"
-        )
-      );
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Error: [files:load"));
+      expect(mocks.currentScreen).toEqual(expect.stringContaining("Error loading file"));
       expect(mocks.currentScreen).toEqual(expect.stringContaining("ALERTS"));
     });
 


### PR DESCRIPTION
## core [unreleased]

### Changed

- refactor(#371): Separate logic about loading files from logic about loading routes and collections from files. Use the new `files.createLoader` method to create routes and collections loaders. closes #371 

### Added
- feat: Expose files API in core.
- feat: Add `createLoader` method to files.
- feat: Add `reload` method to files.

### Fixed
- fix: Debounce time in files reload aw not working. Now it has 200ms of debounce, with a maximum time wait of 1000ms

## main [unreleased]

### Changed

- feat: Log possible start errors
- chore(deps): Update `@mocks-server/core` dependency