### PR TITLE
Release 5.0.0-beta.3

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Do not return root namespace in config.namespaces
 - feat: Throw an error when creating namespace if it already exists, as creating an option does
 - feat: Make itemsType property in options of type 'array' not mandatory
+- feat: Support nullable in options of type 'array' and 'object'
+- feat: Add `unknown` type to options. They support any type and are not validated
 
 ## [1.4.0] - 2022-09-01
 

--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/**/getValidationSchema.spec.js"],
+  // testMatch: ["<rootDir>/test/**/validate.spec.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/config",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Modular configuration provider. Read it from file, environment and arguments",
   "keywords": [
     "configuration",

--- a/packages/config/sonar-project.properties
+++ b/packages/config/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_config
 sonar.projectName=config
-sonar.projectVersion=2.0.0-beta.1
+sonar.projectVersion=2.0.0-beta.2
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -213,6 +213,7 @@ export const Config: ConfigConstructor = class Config implements ConfigInterface
     return getValidationSchema({
       namespaces: this._namespaces,
       allowAdditionalProperties,
+      removeCustomProperties: true,
     });
   }
 

--- a/packages/config/src/Option.ts
+++ b/packages/config/src/Option.ts
@@ -1,7 +1,7 @@
 import EventEmitter from "events";
 
 import deepMerge from "deepmerge";
-import { isUndefined, isEqual } from "lodash";
+import { isUndefined, isEqual, isNull } from "lodash";
 
 import type { UnknownObject } from "./Common.types";
 import { addEventListener, CHANGE } from "./Events";
@@ -12,8 +12,6 @@ import type {
   SetMethodOptions,
   GetOptionValueTypeFromDefinition,
   GetOptionTypeFromDefinition,
-  OptionInterfaceOfType,
-  OptionDefinition,
 } from "./Option.types";
 import { typeIsArray, typeIsObject, optionIsObject, avoidArraysMerge } from "./Typing";
 import { validateOptionAndThrow, validateValueTypeAndThrow } from "./Validation";
@@ -93,7 +91,7 @@ export class Option<T extends OptionDefinitionGeneric, TypeOfValue = void>
   private _clone(
     value: GetOptionValueTypeFromDefinition<T, TypeOfValue>
   ): GetOptionValueTypeFromDefinition<T, TypeOfValue> {
-    if (isUndefined(value)) {
+    if (isUndefined(value) || (this._nullable === true && isNull(value))) {
       return value;
     }
     if (typeIsArray(this._type)) {

--- a/packages/config/src/Validation.types.ts
+++ b/packages/config/src/Validation.types.ts
@@ -1,4 +1,5 @@
 import type { DefinedError } from "ajv";
+import type { JSONSchema7 } from "json-schema";
 
 import type { ConfigNamespaceInterface } from "./Config.types";
 
@@ -13,4 +14,40 @@ export interface ConfigValidationResult {
 export interface GetValidationSchemaOptions {
   namespaces: ConfigNamespaceInterface[];
   allowAdditionalProperties: boolean;
+  // Remove custom AJV keywords from schema
+  removeCustomProperties?: boolean;
+}
+
+export type JSONSchema7WithUnknownDefinition = JSONSchema7WithUnknown | boolean;
+export interface JSONSchema7WithUnknown extends JSONSchema7 {
+  isUnknown?: boolean;
+  $defs?:
+    | {
+        [key: string]: JSONSchema7WithUnknownDefinition;
+      }
+    | undefined;
+
+  items?: JSONSchema7WithUnknownDefinition | JSONSchema7WithUnknownDefinition[];
+  additionalItems?: JSONSchema7WithUnknownDefinition;
+  contains?: JSONSchema7WithUnknown;
+  properties?: {
+    [key: string]: JSONSchema7WithUnknownDefinition;
+  };
+  patternProperties?: {
+    [key: string]: JSONSchema7WithUnknownDefinition;
+  };
+  additionalProperties?: JSONSchema7WithUnknownDefinition | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7WithUnknownDefinition | string[];
+  };
+  propertyNames?: JSONSchema7WithUnknownDefinition;
+
+  if?: JSONSchema7WithUnknownDefinition;
+  then?: JSONSchema7WithUnknownDefinition;
+  else?: JSONSchema7WithUnknownDefinition;
+
+  allOf?: JSONSchema7WithUnknownDefinition[];
+  anyOf?: JSONSchema7WithUnknownDefinition[];
+  oneOf?: JSONSchema7WithUnknownDefinition[];
+  not?: JSONSchema7WithUnknownDefinition;
 }

--- a/packages/config/test/specs/getValidationSchema.spec.js
+++ b/packages/config/test/specs/getValidationSchema.spec.js
@@ -134,12 +134,11 @@ describe("getValidationSchema method", () => {
           foo: {
             type: "object",
             properties: {
-              fooOption: { type: ["boolean", "number", "string", "object", "array"] },
+              fooOption: {},
               fooOption2: {
                 type: "array",
-                items: { type: ["boolean", "number", "string", "object", "array"] },
               },
-              fooOption3: { type: ["boolean", "number", "string", "object", "array", "null"] },
+              fooOption3: {},
             },
             additionalProperties: true,
           },

--- a/packages/config/test/specs/options.spec.js
+++ b/packages/config/test/specs/options.spec.js
@@ -268,6 +268,168 @@ describe("options", () => {
       ).toThrowError("default");
     });
 
+    it("should not throw when type is unknown and default is string", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({ name: "fooOption", type: "unknown", default: "foo" })
+      ).not.toThrow();
+    });
+
+    it("should not throw when type is unknown and default is number", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({ name: "fooOption", type: "unknown", default: 5 })
+      ).not.toThrow();
+    });
+
+    it("should not throw when type is unknown and default is array", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({ name: "fooOption", type: "unknown", default: [] })
+      ).not.toThrow();
+    });
+
+    it("should not throw when type is unknown and default is object", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({ name: "fooOption", type: "unknown", default: {} })
+      ).not.toThrow();
+    });
+
+    it("should not throw when type is unknown and default is function", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "unknown",
+          default: () => {
+            // do nothing
+          },
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when type is unknown and default is boolean", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "unknown",
+          default: false,
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array of strings", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: ["foo"],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array number", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [5],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array of arrays", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [[]],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array object", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [{}],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array of functions", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [
+            () => {
+              // do nothing
+            },
+          ],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is array of boolean", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [false],
+        })
+      ).not.toThrow();
+    });
+
+    it("should not throw when itemsType is unknown and default is a mix of types", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      expect(() =>
+        namespace.addOption({
+          name: "fooOption",
+          type: "array",
+          itemsType: "unknown",
+          default: [
+            false,
+            5,
+            "foo",
+            {},
+            [],
+            () => {
+              // do nothing
+            },
+          ],
+        })
+      ).not.toThrow();
+    });
+
     it("should throw when type is not array and itemsType property is added", async () => {
       config = new Config();
       namespace = config.addNamespace("foo");
@@ -300,6 +462,143 @@ describe("options", () => {
           default: [1, "foo", 3],
         })
       ).toThrowError("default");
+    });
+
+    it("should not throw when setting value if type is unknown and value is string", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({ name: "fooOption", type: "unknown" });
+      expect(() => (opt.value = "bar")).not.toThrow();
+    });
+
+    it("should not throw when setting value if type is unknown and value is number", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({ name: "fooOption", type: "unknown" });
+      expect(() => (opt.value = 10)).not.toThrow();
+    });
+
+    it("should not throw when setting value if type is unknown and value is array", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({ name: "fooOption", type: "unknown" });
+      expect(() => (opt.value = ["foo"])).not.toThrow();
+    });
+
+    it("should not throw when setting value if type is unknown and value is object", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({ name: "fooOption", type: "unknown" });
+      expect(() => (opt.value = { foo: "bar" })).not.toThrow();
+    });
+
+    it("should not throw when setting value if type is unknown and value is function", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "unknown",
+      });
+      expect(
+        () =>
+          (opt.value = () => {
+            // do nothing
+          })
+      ).not.toThrow();
+    });
+
+    it("should not throw when setting value if type is unknown and value is boolean", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "unknown",
+      });
+      expect(() => (opt.value = true)).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is array of strings", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+      });
+      expect(() => (opt.value = ["foo"])).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is array number", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+      });
+      expect(() => (opt.value = [1])).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is array of arrays", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+      });
+      expect(() => (opt.value = [[1]])).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is array of functions", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+      });
+      expect(() => {
+        opt.value = [
+          () => {
+            // do nothing }
+          },
+        ];
+      }).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is array of boolean", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+        default: [false],
+      });
+      expect(() => (opt.value = [true, false])).not.toThrow();
+    });
+
+    it("should not throw when setting value if itemsType is unknown and value is a mix of types", async () => {
+      config = new Config();
+      namespace = config.addNamespace("foo");
+      const opt = namespace.addOption({
+        name: "fooOption",
+        type: "array",
+        itemsType: "unknown",
+      });
+      expect(() => {
+        opt.value = [
+          false,
+          5,
+          "foo",
+          {},
+          [],
+          () => {
+            // do nothing
+          },
+        ];
+      }).not.toThrow();
     });
 
     it("should throw when setting value if type is array and value does not match type", async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/core",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Pluggable mock server supporting multiple route variants and mocks",
   "keywords": [
     "mocks",
@@ -70,7 +70,7 @@
     "node": ">=14.x"
   },
   "devDependencies": {
-    "@types/babel__register": "^7.17.0",
+    "@types/babel__register": "7.17.0",
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17",
     "@types/globule": "1.1.6",

--- a/packages/core/sonar-project.properties
+++ b/packages/core/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_core
 sonar.projectName=core
-sonar.projectVersion=5.0.0-beta.1
+sonar.projectVersion=5.0.0-beta.2
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -16,7 +16,6 @@ import {
   ConfigInterface,
   ConfigurationObject,
   ConfigNamespaceInterface,
-  OptionDefinition,
   OptionInterfaceOfType,
 } from "@mocks-server/config";
 import { Logger, LoggerInterface, LogLevel } from "@mocks-server/logger";
@@ -26,7 +25,12 @@ import { readJsonSync } from "fs-extra";
 import { Alerts } from "./alerts";
 import type { AlertsInterface } from "./alerts/types";
 import { CHANGE_MOCK, CHANGE_ALERTS, arrayMerge } from "./common";
-import type { CoreInterface, CoreConstructor, CoreAdvancedOptions } from "./Core.types";
+import type {
+  CoreInterface,
+  CoreConstructor,
+  CoreAdvancedOptions,
+  LogOptionDefinition,
+} from "./Core.types";
 import { Files } from "./files";
 import type { FilesInterface } from "./files/types";
 import { Mock } from "./mock";
@@ -44,7 +48,7 @@ import type { VariantHandlersInterface } from "./variant-handlers/types";
 
 const MODULE_NAME = "mocks";
 
-const ROOT_OPTIONS: [OptionDefinition<string, { hasDefault: true }>] = [
+const ROOT_OPTIONS: [LogOptionDefinition] = [
   {
     description: "Log level. Can be one of silly, debug, verbose, info, warn or error",
     name: "log",

--- a/packages/core/src/Core.types.ts
+++ b/packages/core/src/Core.types.ts
@@ -8,8 +8,13 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type { ConfigInterface, ConfigurationObject } from "@mocks-server/config";
-import type { LoggerInterface } from "@mocks-server/logger";
+import type {
+  ConfigInterface,
+  ConfigurationObject,
+  GetOptionValueTypeFromDefinition,
+  OptionDefinition,
+} from "@mocks-server/config";
+import type { LoggerInterface, LogLevel } from "@mocks-server/logger";
 import type { Package } from "update-notifier";
 
 import type { AlertsInterface } from "./alerts/types";
@@ -17,6 +22,25 @@ import type { FilesInterface } from "./files/types";
 import type { MockInterface } from "./mock/types";
 import type { ServerInterface } from "./server/types";
 import type { VariantHandlersInterface } from "./variant-handlers/types";
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    //eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Config {}
+  }
+}
+
+export type LogOptionDefinition = OptionDefinition<string, { hasDefault: true }>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface Config {
+      log?: GetOptionValueTypeFromDefinition<LogOptionDefinition, LogLevel>;
+    }
+  }
+}
 
 /** Mocks-server base core interface */
 export interface BaseCoreInterface {

--- a/packages/core/src/files/Files.ts
+++ b/packages/core/src/files/Files.ts
@@ -39,6 +39,11 @@ import type {
   FilesInterface,
   FilesOptions,
   FilesLoaders,
+  FilesEnabledOptionDefinition,
+  FilesPathOptionDefinition,
+  FilesWatchOptionDefinition,
+  BabelEnabledOptionDefinition,
+  BabelConfigOptionDefinition,
 } from "./Files.types";
 import { FilesLoader } from "./FilesLoader";
 import type { FilesLoaderInterface, FileLoaded, ErrorLoadingFile } from "./FilesLoader.types";
@@ -52,9 +57,9 @@ import {
 } from "./Helpers";
 
 const OPTIONS: [
-  OptionDefinition<boolean, { hasDefault: true }>,
-  OptionDefinition<string, { hasDefault: true }>,
-  OptionDefinition<boolean, { hasDefault: true }>
+  FilesEnabledOptionDefinition,
+  FilesPathOptionDefinition,
+  FilesWatchOptionDefinition
 ] = [
   {
     name: "enabled",
@@ -78,10 +83,7 @@ const OPTIONS: [
 
 const BABEL_REGISTER_NAMESPACE = "babelRegister";
 
-const BABEL_REGISTER_OPTIONS: [
-  OptionDefinition<boolean, { hasDefault: true }>,
-  OptionDefinition<UnknownObject, { hasDefault: true }>
-] = [
+const BABEL_REGISTER_OPTIONS: [BabelEnabledOptionDefinition, BabelConfigOptionDefinition] = [
   {
     name: "enabled",
     description: "Load @babel/register",

--- a/packages/core/src/files/Files.types.ts
+++ b/packages/core/src/files/Files.types.ts
@@ -8,7 +8,13 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type { ConfigNamespaceInterface } from "@mocks-server/config";
+import type { RegisterOptions } from "@babel/register";
+import type {
+  ConfigNamespaceInterface,
+  OptionDefinition,
+  UnknownObject,
+  GetOptionValueTypeFromDefinition,
+} from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { AlertsInterface } from "../alerts/types";
@@ -19,6 +25,30 @@ import type {
   FilesLoaderId,
   FilesLoaderOnLoadMethod,
 } from "./FilesLoader.types";
+
+export type FilesEnabledOptionDefinition = OptionDefinition<boolean, { hasDefault: true }>;
+export type FilesPathOptionDefinition = OptionDefinition<string, { hasDefault: true }>;
+export type FilesWatchOptionDefinition = OptionDefinition<boolean, { hasDefault: true }>;
+
+export type BabelEnabledOptionDefinition = OptionDefinition<boolean, { hasDefault: true }>;
+export type BabelConfigOptionDefinition = OptionDefinition<UnknownObject, { hasDefault: true }>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface Config {
+      files?: {
+        enabled?: GetOptionValueTypeFromDefinition<FilesEnabledOptionDefinition>;
+        path?: GetOptionValueTypeFromDefinition<FilesPathOptionDefinition>;
+        watch?: GetOptionValueTypeFromDefinition<FilesWatchOptionDefinition>;
+        babelRegister?: {
+          enabled?: GetOptionValueTypeFromDefinition<BabelEnabledOptionDefinition>;
+          config?: GetOptionValueTypeFromDefinition<BabelConfigOptionDefinition, RegisterOptions>;
+        };
+      };
+    }
+  }
+}
 
 /** Options for creating a files loader */
 export interface CreateFilesLoaderOptions {

--- a/packages/core/src/mock/Mock.types.ts
+++ b/packages/core/src/mock/Mock.types.ts
@@ -28,6 +28,18 @@ import type {
 } from "./definitions/types";
 import type { RouteId, RoutesInterface } from "./routes/types";
 
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface ConfigMockNamespace {}
+
+    interface Config {
+      mock?: ConfigMockNamespace;
+    }
+  }
+}
+
 export type CollectionDefinitionsManager = DefinitionLoadersManagerInterface<CollectionDefinition>;
 export type CollectionDefinitionsLoader = DefinitionsLoaderInterface<CollectionDefinition>["load"];
 

--- a/packages/core/src/mock/collections/Collections.ts
+++ b/packages/core/src/mock/collections/Collections.ts
@@ -8,11 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type {
-  ConfigNamespaceInterface,
-  OptionInterfaceOfType,
-  OptionDefinition,
-} from "@mocks-server/config";
+import type { ConfigNamespaceInterface, OptionInterfaceOfType } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 import { compact } from "lodash";
 
@@ -33,6 +29,7 @@ import type {
   CollectionsOptions,
   SelectCollectionOptionsNoPromise,
   SelectCollectionOptionsPromise,
+  SelectedCollectionOptionDefinition,
 } from "./Collections.types";
 import {
   collectionRouteVariantsValidationErrors,
@@ -42,7 +39,7 @@ import {
 } from "./CollectionsValidator";
 import { addRoutesToCollectionRoutes } from "./Helpers";
 
-const OPTIONS: [OptionDefinition<string>] = [
+const OPTIONS: [SelectedCollectionOptionDefinition] = [
   {
     description: "Selected collection",
     name: "selected",

--- a/packages/core/src/mock/collections/Collections.types.ts
+++ b/packages/core/src/mock/collections/Collections.types.ts
@@ -8,7 +8,11 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type { ConfigNamespaceInterface } from "@mocks-server/config";
+import type {
+  ConfigNamespaceInterface,
+  OptionDefinition,
+  GetOptionValueTypeFromDefinition,
+} from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { AlertsInterface } from "../../alerts/types";
@@ -21,6 +25,19 @@ import type {
   CollectionPlainObject,
   CollectionPlainObjectLegacy,
 } from "./Collection.types";
+
+export type SelectedCollectionOptionDefinition = OptionDefinition<string>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface ConfigMockNamespace {
+      collections?: {
+        selected?: GetOptionValueTypeFromDefinition<SelectedCollectionOptionDefinition>;
+      };
+    }
+  }
+}
 
 /** Options for creating a Collections interface */
 export interface CollectionsOptions {

--- a/packages/core/src/mock/routes/Routes.ts
+++ b/packages/core/src/mock/routes/Routes.ts
@@ -8,11 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type {
-  ConfigNamespaceInterface,
-  OptionInterfaceOfType,
-  OptionDefinition,
-} from "@mocks-server/config";
+import type { ConfigNamespaceInterface, OptionInterfaceOfType } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 import { flatten, compact, isUndefined } from "lodash";
 
@@ -42,7 +38,12 @@ import type {
   RoutePlainObjectLegacy,
   RouteVariantPlainObjectLegacy,
 } from "./Route.types";
-import type { RoutesConstructor, RoutesInterface, RoutesOptions } from "./Routes.types";
+import type {
+  DelayOptionDefinition,
+  RoutesConstructor,
+  RoutesInterface,
+  RoutesOptions,
+} from "./Routes.types";
 import {
   routeValidationErrors,
   variantValidationErrors,
@@ -51,7 +52,7 @@ import {
 
 const LOAD_NAMESPACE = "load";
 
-const OPTIONS: [OptionDefinition<number, { hasDefault: true }>] = [
+const OPTIONS: [DelayOptionDefinition] = [
   {
     description: "Global delay to apply to routes",
     name: "delay",

--- a/packages/core/src/mock/routes/Routes.types.ts
+++ b/packages/core/src/mock/routes/Routes.types.ts
@@ -8,7 +8,11 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type { ConfigNamespaceInterface } from "@mocks-server/config";
+import type {
+  ConfigNamespaceInterface,
+  OptionDefinition,
+  GetOptionValueTypeFromDefinition,
+} from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { AlertsInterface } from "../../alerts/types";
@@ -24,6 +28,19 @@ import type {
   RoutePlainObjectLegacy,
   RouteVariantPlainObjectLegacy,
 } from "./Route.types";
+
+export type DelayOptionDefinition = OptionDefinition<number, { hasDefault: true }>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface ConfigMockNamespace {
+      routes?: {
+        delay?: GetOptionValueTypeFromDefinition<DelayOptionDefinition>;
+      };
+    }
+  }
+}
 
 /** Options for creating a Routes interface */
 export interface RoutesOptions {

--- a/packages/core/src/plugins/Plugins.ts
+++ b/packages/core/src/plugins/Plugins.ts
@@ -8,11 +8,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type {
-  ConfigNamespaceInterface,
-  OptionInterfaceOfType,
-  OptionDefinition,
-} from "@mocks-server/config";
+import type { ConfigNamespaceInterface, OptionInterfaceOfType } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 import isPromise from "is-promise";
 import { isFunction } from "lodash";
@@ -31,9 +27,10 @@ import type {
   PluginId,
   PluginWithError,
   PluginLifeCycleMethod,
+  PluginsOptionDefinition,
 } from "./Plugins.types";
 
-const OPTIONS: [OptionDefinition<PluginConstructor[], { hasDefault: true }>] = [
+const OPTIONS: [PluginsOptionDefinition] = [
   {
     description: "Plugins to be registered",
     name: "register",

--- a/packages/core/src/plugins/Plugins.ts
+++ b/packages/core/src/plugins/Plugins.ts
@@ -38,6 +38,7 @@ const OPTIONS: [OptionDefinition<PluginConstructor[], { hasDefault: true }>] = [
     description: "Plugins to be registered",
     name: "register",
     type: "array",
+    itemsType: "unknown",
     default: [],
     extraData: {
       scaffold: {

--- a/packages/core/src/plugins/Plugins.types.ts
+++ b/packages/core/src/plugins/Plugins.types.ts
@@ -8,12 +8,30 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import type { ConfigNamespaceInterface } from "@mocks-server/config";
+import type {
+  ConfigNamespaceInterface,
+  OptionDefinition,
+  GetOptionValueTypeFromDefinition,
+} from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { AlertsInterface } from "../alerts/types";
 import type { ScopedCoreInterface } from "../common/types";
 import type { CoreInterface } from "../Core.types";
+
+export type PluginsOptionDefinition = OptionDefinition<PluginConstructor[], { hasDefault: true }>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface PluginsConfig {
+      register?: GetOptionValueTypeFromDefinition<PluginsOptionDefinition, PluginConstructor[]>;
+    }
+    interface Config {
+      plugins?: PluginsConfig;
+    }
+  }
+}
 
 /** Options for creating a plugins interface */
 export interface PluginsOptions {

--- a/packages/core/src/server/ServerOptions.ts
+++ b/packages/core/src/server/ServerOptions.ts
@@ -1,11 +1,20 @@
-import type { OptionDefinition, UnknownObject } from "@mocks-server/config";
+import type {
+  CorsEnabledOptionDefinition,
+  CorsOptionsOptionDefinition,
+  HostOptionDefinition,
+  HttpsCertOptionDefinition,
+  HttpsKeyOptionDefinition,
+  HttpsProtocolOptionDefinition,
+  JsonBodyParserEnabledOptionDefinition,
+  JsonBodyParserOptionsOptionDefinition,
+  PortNumberOptionDefinition,
+  UrlEncodedBodyParserEnabledOptionDefinition,
+  UrlEncodedBodyParserOptionsOptionDefinition,
+} from "./ServerOptions.types";
 
 export const ALL_HOSTS = "0.0.0.0";
 
-export const OPTIONS: [
-  OptionDefinition<number, { hasDefault: true }>,
-  OptionDefinition<string, { hasDefault: true }>
-] = [
+export const OPTIONS: [PortNumberOptionDefinition, HostOptionDefinition] = [
   {
     description: "Port number for the server to be listening at",
     name: "port",
@@ -23,9 +32,9 @@ export const OPTIONS: [
 export const HTTPS_NAMESPACE = "https";
 
 export const HTTPS_OPTIONS: [
-  OptionDefinition<boolean, { hasDefault: true }>,
-  OptionDefinition<string>,
-  OptionDefinition<string>
+  HttpsProtocolOptionDefinition,
+  HttpsCertOptionDefinition,
+  HttpsKeyOptionDefinition
 ] = [
   {
     description: "Use https protocol or not",
@@ -47,10 +56,7 @@ export const HTTPS_OPTIONS: [
 
 export const CORS_NAMESPACE = "cors";
 
-export const CORS_OPTIONS: [
-  OptionDefinition<boolean>,
-  OptionDefinition<UnknownObject, { hasDefault: true }>
-] = [
+export const CORS_OPTIONS: [CorsEnabledOptionDefinition, CorsOptionsOptionDefinition] = [
   {
     description: "Use CORS middleware or not",
     name: "enabled",
@@ -71,8 +77,8 @@ export const CORS_OPTIONS: [
 export const JSON_BODY_PARSER_NAMESPACE = "jsonBodyParser";
 
 export const JSON_BODY_PARSER_OPTIONS: [
-  OptionDefinition<boolean, { hasDefault: true }>,
-  OptionDefinition<UnknownObject, { hasDefault: true }>
+  JsonBodyParserEnabledOptionDefinition,
+  JsonBodyParserOptionsOptionDefinition
 ] = [
   {
     description: "Use json body-parser middleware or not",
@@ -92,8 +98,8 @@ export const JSON_BODY_PARSER_OPTIONS: [
 export const URL_ENCODED_BODY_PARSER_NAMESPACE = "urlEncodedBodyParser";
 
 export const URL_ENCODED_BODY_PARSER_OPTIONS: [
-  OptionDefinition<boolean, { hasDefault: true }>,
-  OptionDefinition<UnknownObject, { hasDefault: true }>
+  UrlEncodedBodyParserEnabledOptionDefinition,
+  UrlEncodedBodyParserOptionsOptionDefinition
 ] = [
   {
     description: "Use urlencoded body-parser middleware or not",

--- a/packages/core/src/server/ServerOptions.types.ts
+++ b/packages/core/src/server/ServerOptions.types.ts
@@ -1,0 +1,72 @@
+import type {
+  OptionDefinition,
+  UnknownObject,
+  GetOptionValueTypeFromDefinition,
+} from "@mocks-server/config";
+import type { OptionsJson, OptionsUrlencoded } from "body-parser";
+import type { CorsOptions } from "cors";
+
+export const ALL_HOSTS = "0.0.0.0";
+
+export type PortNumberOptionDefinition = OptionDefinition<number, { hasDefault: true }>;
+export type HostOptionDefinition = OptionDefinition<string, { hasDefault: true }>;
+
+export type HttpsProtocolOptionDefinition = OptionDefinition<boolean, { hasDefault: true }>;
+export type HttpsCertOptionDefinition = OptionDefinition<string>;
+export type HttpsKeyOptionDefinition = OptionDefinition<string>;
+
+export type CorsEnabledOptionDefinition = OptionDefinition<boolean>;
+export type CorsOptionsOptionDefinition = OptionDefinition<UnknownObject, { hasDefault: true }>;
+
+export type JsonBodyParserEnabledOptionDefinition = OptionDefinition<
+  boolean,
+  { hasDefault: true }
+>;
+export type JsonBodyParserOptionsOptionDefinition = OptionDefinition<
+  UnknownObject,
+  { hasDefault: true }
+>;
+
+export type UrlEncodedBodyParserEnabledOptionDefinition = OptionDefinition<
+  boolean,
+  { hasDefault: true }
+>;
+export type UrlEncodedBodyParserOptionsOptionDefinition = OptionDefinition<
+  UnknownObject,
+  { hasDefault: true }
+>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface Config {
+      server?: {
+        port?: GetOptionValueTypeFromDefinition<PortNumberOptionDefinition>;
+        host?: GetOptionValueTypeFromDefinition<HostOptionDefinition>;
+        https?: {
+          enabled?: GetOptionValueTypeFromDefinition<HttpsProtocolOptionDefinition>;
+          cert?: GetOptionValueTypeFromDefinition<HttpsCertOptionDefinition>;
+          key?: GetOptionValueTypeFromDefinition<HttpsKeyOptionDefinition>;
+        };
+        cors?: {
+          enabled?: GetOptionValueTypeFromDefinition<CorsEnabledOptionDefinition>;
+          options?: GetOptionValueTypeFromDefinition<CorsOptionsOptionDefinition, CorsOptions>;
+        };
+        jsonBodyParser?: {
+          enabled?: GetOptionValueTypeFromDefinition<JsonBodyParserEnabledOptionDefinition>;
+          options?: GetOptionValueTypeFromDefinition<
+            JsonBodyParserOptionsOptionDefinition,
+            OptionsJson
+          >;
+        };
+        urlEncodedBodyParser?: {
+          enabled?: GetOptionValueTypeFromDefinition<UrlEncodedBodyParserEnabledOptionDefinition>;
+          options?: GetOptionValueTypeFromDefinition<
+            UrlEncodedBodyParserOptionsOptionDefinition,
+            OptionsUrlencoded
+          >;
+        };
+      };
+    }
+  }
+}

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -9,3 +9,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 export * from "./Server.types";
+export * from "./ServerOptions.types";

--- a/packages/core/src/variant-handlers/VariantHandlers.ts
+++ b/packages/core/src/variant-handlers/VariantHandlers.ts
@@ -7,11 +7,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
-import type {
-  ConfigNamespaceInterface,
-  OptionInterfaceOfType,
-  OptionDefinition,
-} from "@mocks-server/config";
+import type { ConfigNamespaceInterface, OptionInterfaceOfType } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import {
@@ -26,10 +22,11 @@ import type {
   VariantHandlerConstructor,
   VariantHandlersConstructor,
   VariantHandlersInterface,
+  VariantHandlersOptionDefinition,
   VariantHandlersOptions,
 } from "./types";
 
-const OPTIONS: [OptionDefinition<VariantHandlerConstructor[], { hasDefault: true }>] = [
+const OPTIONS: [VariantHandlersOptionDefinition] = [
   {
     description: "Variant Handlers to be registered",
     name: "register",

--- a/packages/core/src/variant-handlers/VariantHandlers.ts
+++ b/packages/core/src/variant-handlers/VariantHandlers.ts
@@ -34,6 +34,7 @@ const OPTIONS: [OptionDefinition<VariantHandlerConstructor[], { hasDefault: true
     description: "Variant Handlers to be registered",
     name: "register",
     type: "array",
+    itemsType: "unknown",
     default: [],
   },
 ];

--- a/packages/core/src/variant-handlers/VariantHandlers.types.ts
+++ b/packages/core/src/variant-handlers/VariantHandlers.types.ts
@@ -7,12 +7,35 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
-import type { ConfigNamespaceInterface } from "@mocks-server/config";
+import type {
+  ConfigNamespaceInterface,
+  GetOptionValueTypeFromDefinition,
+  OptionDefinition,
+} from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { UnknownObject, JSONValue } from "../common/types";
 import type { JSONSchema7WithInstanceof } from "../mock/types";
 import type { NextFunction, Request, Response, RequestHandler } from "../server/types";
+
+export type VariantHandlersOptionDefinition = OptionDefinition<
+  VariantHandlerConstructor[],
+  { hasDefault: true }
+>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface Config {
+      variantHandlers?: {
+        register?: GetOptionValueTypeFromDefinition<
+          VariantHandlersOptionDefinition,
+          VariantHandlerConstructor[]
+        >;
+      };
+    }
+  }
+}
 
 /** Response preview */
 export interface VariantHandlerResponsePreview {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/main",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "description": "Mock Server supporting multiple route variants and mocks",
   "keywords": [
     "mock",

--- a/packages/main/sonar-project.properties
+++ b/packages/main/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main
 sonar.projectName=main
-sonar.projectVersion=5.0.0-beta.2
+sonar.projectVersion=5.0.0-beta.3
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/plugin-admin-api/package.json
+++ b/packages/plugin-admin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-admin-api",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "description": "Mocks Server plugin providing an administration REST API",
   "keywords": [
     "mocks-server-plugin",
@@ -32,7 +32,7 @@
     "test:unit": "jest --runInBand"
   },
   "peerDependencies": {
-    "@mocks-server/core": "5.0.0-beta.1"
+    "@mocks-server/core": "5.0.0-beta.2"
   },
   "dependencies": {
     "@hapi/boom": "9.1.4",

--- a/packages/plugin-admin-api/sonar-project.properties
+++ b/packages/plugin-admin-api/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_plugin-admin-api
 sonar.projectName=plugin-admin-api
-sonar.projectVersion=5.0.0-beta.2
+sonar.projectVersion=5.0.0-beta.3
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/plugin-inquirer-cli/package.json
+++ b/packages/plugin-inquirer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-inquirer-cli",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "description": "Mocks server plugin providing an interactive CLI",
   "keywords": [
     "mocks-server-plugin",
@@ -32,7 +32,7 @@
     "test:unit": "jest"
   },
   "peerDependencies": {
-    "@mocks-server/core": "5.0.0-beta.1"
+    "@mocks-server/core": "5.0.0-beta.2"
   },
   "dependencies": {
     "chalk": "4.1.1",

--- a/packages/plugin-inquirer-cli/sonar-project.properties
+++ b/packages/plugin-inquirer-cli/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_plugin-inquirer-cli
 sonar.projectName=plugin-inquirer-cli
-sonar.projectVersion=5.0.0-beta.2
+sonar.projectVersion=5.0.0-beta.3
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-openapi",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "Mocks server plugin allowing to create routes and collections from OpenApi definitions",
   "keywords": [
     "mocks-server-plugin",
@@ -32,7 +32,7 @@
     "test:unit": "jest --runInBand"
   },
   "peerDependencies": {
-    "@mocks-server/core": "5.0.0-beta.1"
+    "@mocks-server/core": "5.0.0-beta.2"
   },
   "dependencies": {
     "openapi-types": "12.0.2",

--- a/packages/plugin-openapi/sonar-project.properties
+++ b/packages/plugin-openapi/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_plugin-openapi
 sonar.projectName=plugin-openapi
-sonar.projectVersion=3.0.0-beta.2
+sonar.projectVersion=3.0.0-beta.3
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/plugin-openapi/src/Plugin.ts
+++ b/packages/plugin-openapi/src/Plugin.ts
@@ -15,26 +15,29 @@ import type {
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import { openApiRoutes } from "./OpenApi";
-import type { OpenApiDefinition, PluginConstructor, PluginInterface } from "./types";
+import type {
+  CollectionFromOptionDefinition,
+  CollectionIdOptionDefinition,
+  OpenApiDefinition,
+  PluginConstructor,
+  PluginInterface,
+} from "./types";
 
 const PLUGIN_ID = "openapi";
 const DEFAULT_FOLDER = "openapi";
 
 const COLLECTION_NAMESPACE = "collection";
 
-const COLLECTION_OPTIONS: [
-  OptionDefinition<string, { hasDefault: true }>,
-  OptionDefinition<string>
-] = [
+const COLLECTION_OPTIONS: [CollectionIdOptionDefinition, CollectionFromOptionDefinition] = [
   {
-    description: "Name for the collection created from OpenAPI definitions",
+    description: "Id for the collection created from OpenAPI definitions",
     name: "id",
     type: "string",
     nullable: true,
     default: "openapi",
   },
   {
-    description: "Name of the collection to extend from",
+    description: "Id of the collection to extend from",
     name: "from",
     type: "string",
   },

--- a/packages/plugin-openapi/src/Plugin.types.ts
+++ b/packages/plugin-openapi/src/Plugin.types.ts
@@ -1,4 +1,25 @@
+import type { OptionDefinition, GetOptionValueTypeFromDefinition } from "@mocks-server/config";
 import type { ScopedCoreInterface, PluginId } from "@mocks-server/core";
+
+export type CollectionIdOptionDefinition = OptionDefinition<
+  string,
+  { hasDefault: true; nullable: true }
+>;
+export type CollectionFromOptionDefinition = OptionDefinition<string>;
+
+declare global {
+  //eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace MocksServer {
+    interface PluginsConfig {
+      openapi?: {
+        collection?: {
+          id?: GetOptionValueTypeFromDefinition<CollectionIdOptionDefinition>;
+          from?: GetOptionValueTypeFromDefinition<CollectionFromOptionDefinition>;
+        };
+      };
+    }
+  }
+}
 
 /** Plugin constructor */
 export interface PluginConstructor {

--- a/packages/plugin-proxy/package.json
+++ b/packages/plugin-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-proxy",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "description": "Mocks Server plugin providing proxy variant handler",
   "keywords": [
     "mocks-server-plugin",
@@ -33,7 +33,7 @@
     "test:unit": "jest --runInBand"
   },
   "peerDependencies": {
-    "@mocks-server/core": "5.0.0-beta.1"
+    "@mocks-server/core": "5.0.0-beta.2"
   },
   "dependencies": {
     "express-http-proxy": "1.6.3"

--- a/packages/plugin-proxy/sonar-project.properties
+++ b/packages/plugin-proxy/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server_main_plugin-proxy
 sonar.projectName=plugin-proxy
-sonar.projectVersion=5.0.0-beta.2
+sonar.projectVersion=5.0.0-beta.3
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,7 +243,7 @@ importers:
       '@mocks-server/config': workspace:*
       '@mocks-server/logger': workspace:*
       '@mocks-server/nested-collections': workspace:*
-      '@types/babel__register': ^7.17.0
+      '@types/babel__register': 7.17.0
       '@types/cors': 2.8.13
       '@types/express': 4.17.17
       '@types/globule': 1.1.6
@@ -3590,8 +3590,8 @@ packages:
   /@types/babel__core/7.1.18:
     resolution: {integrity: sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==}
     dependencies:
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.18.10
+      '@babel/parser': 7.18.13
+      '@babel/types': 7.18.13
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.14.2
@@ -3600,7 +3600,7 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
     dev: true
 
   /@types/babel__register/7.17.0:
@@ -3612,14 +3612,14 @@ packages:
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.18.10
+      '@babel/parser': 7.18.13
+      '@babel/types': 7.18.13
     dev: true
 
   /@types/babel__traverse/7.14.2:
     resolution: {integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
     dev: true
 
   /@types/body-parser/1.19.2:

--- a/test/admin-api-client-data-provider-e2e-specs/cypress/integration/about.js
+++ b/test/admin-api-client-data-provider-e2e-specs/cypress/integration/about.js
@@ -11,12 +11,12 @@ describe("About section", () => {
   it("should display current core version", () => {
     cy.findByTestId(SELECTORS.CORE_VERSION)
       .invoke("text")
-      .should("match", /^(?:\d+\.)(?:\d+\.)(?:\*|\d+)-beta.1$/);
+      .should("match", /^(?:\d+\.)(?:\d+\.)(?:\*|\d+)-beta.\d$/);
   });
 
   it("should display current admin api version", () => {
     cy.findByTestId(SELECTORS.ADMINAPI_VERSION)
       .invoke("text")
-      .should("match", /^(?:\d+\.)(?:\d+\.)(?:\*|\d+)-beta.1$/);
+      .should("match", /^(?:\d+\.)(?:\d+\.)(?:\*|\d+)-beta.\d$/);
   });
 });


### PR DESCRIPTION
## Config

- feat: Support nullable in options of type 'array' and 'object'
- feat: Add `unknown` type to options. They support any type and are not validated

## Core

- feat: add MocksServer.Config interface allowing to type the configuration, and to extend it from plugins

